### PR TITLE
Custom (Uknown) Measure 

### DIFF
--- a/agent/src/main/scala/za/co/absa/atum/agent/model/Measure.scala
+++ b/agent/src/main/scala/za/co/absa/atum/agent/model/Measure.scala
@@ -35,6 +35,8 @@ trait AtumMeasure extends Measure with MeasurementProcessor {
   val resultValueType: ResultValueType.ResultValueType
 }
 
+final case class UnknownMeasure(measureName: String, controlColumns: Seq[String]) extends Measure
+
 object AtumMeasure {
 
   val supportedMeasureNames: Seq[String] = Seq(

--- a/agent/src/main/scala/za/co/absa/atum/agent/model/Measurement.scala
+++ b/agent/src/main/scala/za/co/absa/atum/agent/model/Measurement.scala
@@ -84,6 +84,25 @@ object Measurement {
           )
       }
     }
+
+    def apply[T](unknownMeasure: UnknownMeasure, resultValue: T): MeasurementProvided[T] = {
+      resultValue match {
+        case _: Long =>
+          MeasurementProvided[T](unknownMeasure, resultValue, ResultValueType.Long)
+        case _: Double =>
+          MeasurementProvided[T](unknownMeasure, resultValue, ResultValueType.Double)
+        case _: BigDecimal =>
+          MeasurementProvided[T](unknownMeasure, resultValue, ResultValueType.BigDecimal)
+        case _: String =>
+          MeasurementProvided[T](unknownMeasure, resultValue, ResultValueType.String)
+        case unsupportedType =>
+          val className = unsupportedType.getClass.getSimpleName
+          throw MeasurementProvidedException(
+            s"Unsupported type of measurement for unknown measure ${unknownMeasure.measureName}: $className " +
+              s"for provided result: $resultValue"
+          )
+      }
+    }
   }
 
     /**

--- a/agent/src/test/scala/za/co/absa/atum/agent/model/MeasurementTest.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/model/MeasurementTest.scala
@@ -58,4 +58,51 @@ class MeasurementTest extends AnyFlatSpec with Matchers with SparkTestBase { sel
     val measure = SumOfValuesOfColumn("col")
     assertThrows[MeasurementProvidedException](MeasurementProvided(measure, 1.0))
   }
+
+
+  "apply" should "create MeasurementProvided for custom measure with String result value type" in {
+    val measureName = "myCustomMeasure"
+    val controlCol = "columnName"
+    val resultValue = "abc"
+
+    val expectedMeasurementProvided = MeasurementProvided(
+      UnknownMeasure(measureName, Seq(controlCol)), resultValue, ResultValueType.String
+    )
+    val actualMeasurementProvided = MeasurementProvided(UnknownMeasure(measureName, Seq(controlCol)), "abc")
+
+    assert(expectedMeasurementProvided == actualMeasurementProvided)
+  }
+
+  "apply" should "create MeasurementProvided for custom measure with Long result value type" in {
+    val measureName = "myCustomMeasure"
+    val controlCol = "columnName"
+    val resultValue = 123L
+
+    val expectedMeasurementProvided = MeasurementProvided(
+      UnknownMeasure(measureName, Seq(controlCol)), resultValue, ResultValueType.Long
+    )
+    val actualMeasurementProvided = MeasurementProvided(UnknownMeasure(measureName, Seq(controlCol)), 123L)
+
+    assert(expectedMeasurementProvided == actualMeasurementProvided)
+  }
+
+  "apply" should "create MeasurementProvided for custom measure with Double result value type" in {
+    val measureName = "myCustomMeasure"
+    val controlCol = "columnName"
+    val resultValue = 1.13
+
+    val expectedMeasurementProvided = MeasurementProvided(
+      UnknownMeasure(measureName, Seq(controlCol)), resultValue, ResultValueType.Double
+    )
+    val actualMeasurementProvided = MeasurementProvided(UnknownMeasure(measureName, Seq(controlCol)), 1.13)
+
+    assert(expectedMeasurementProvided == actualMeasurementProvided)
+  }
+
+  "apply" should "throw exception for unsupported type" in {
+    val measureName = "myCustomMeasure"
+    val controlCol = "columnName"
+
+    assertThrows[MeasurementProvidedException](MeasurementProvided(UnknownMeasure(measureName, Seq(controlCol)), true))
+  }
 }


### PR DESCRIPTION
Introduces `UknownMeasure` type for data provided by client applications in case such a measure doesn't exist in Atum yet.
Closes #99 