### PR TITLE
Feature/create capture dispatcher

### DIFF
--- a/agent/src/main/scala/za/co/absa/atum/agent/AtumAgent.scala
+++ b/agent/src/main/scala/za/co/absa/atum/agent/AtumAgent.scala
@@ -22,7 +22,7 @@ import za.co.absa.atum.agent.dispatcher.{CapturingDispatcher, ConsoleDispatcher,
 import za.co.absa.atum.model.dto.{AdditionalDataSubmitDTO, CheckpointDTO, PartitioningSubmitDTO}
 
 /**
- * Entity that communicate with the API, primarily focused on spawning Atum Context(s).
+ *  Entity that communicate with the API, primarily focused on spawning Atum Context(s).
  */
 abstract class AtumAgent private[agent] () {
 
@@ -31,36 +31,36 @@ abstract class AtumAgent private[agent] () {
   protected val dispatcher: Dispatcher
 
   /**
-   * Returns a user under who's security context the JVM is running.
-   * It's purpose is for auditing in author/createdBy fields.
+   *  Returns a user under who's security context the JVM is running.
+   *  It's purpose is for auditing in author/createdBy fields.
    *
-   * Important: It's not supposed to be used for authorization as it can be spoofed!
+   *  Important: It's not supposed to be used for authorization as it can be spoofed!
    *
-   * @return Current user.
+   *  @return Current user.
    */
   private[agent] def currentUser: String = System.getProperty("user.name") // platform independent
 
   /**
-   * Sends `CheckpointDTO` to the AtumService API
+   *  Sends `CheckpointDTO` to the AtumService API
    *
-   * @param checkpoint Already initialized Checkpoint object to store
+   *  @param checkpoint Already initialized Checkpoint object to store
    */
-  private [agent] def saveCheckpoint(checkpoint: CheckpointDTO): Unit = {
+  private[agent] def saveCheckpoint(checkpoint: CheckpointDTO): Unit = {
     dispatcher.saveCheckpoint(checkpoint)
   }
 
   /**
-   * Sends the `Metadata` to the Atumservice API
-   * @param additionalData the metadata to be saved to the server.
+   *  Sends the `Metadata` to the Atumservice API
+   *  @param additionalData the metadata to be saved to the server.
    */
-  private [agent] def saveAdditionalData(additionalData: AdditionalDataSubmitDTO): Unit = {
+  private[agent] def saveAdditionalData(additionalData: AdditionalDataSubmitDTO): Unit = {
     dispatcher.saveAdditionalData(additionalData)
   }
 
   /**
-   * Provides an AtumContext given a `AtumPartitions` instance. Retrieves the data from AtumService API.
+   *  Provides an AtumContext given a `AtumPartitions` instance. Retrieves the data from AtumService API.
    *
-   * Note: if partitioning doesn't exist in the store yet, a new one will be created with the author stored in
+   *  Note: if partitioning doesn't exist in the store yet, a new one will be created with the author stored in
    *    `AtumAgent.currentUser`. If partitioning already exists, this attribute will be ignored because there
    *    already is an author who previously created the partitioning in the data store. Each Atum Context thus
    *    can have different author potentially.
@@ -80,11 +80,11 @@ abstract class AtumAgent private[agent] () {
   }
 
   /**
-   * Provides an AtumContext given a `AtumPartitions` instance for sub partitions.
-   * Retrieves the data from AtumService API.
-   * @param subPartitions Sub partitions based on which an Atum Context will be created or obtained.
-   * @param parentAtumContext Parent AtumContext.
-   * @return Atum context object
+   *  Provides an AtumContext given a `AtumPartitions` instance for sub partitions.
+   *  Retrieves the data from AtumService API.
+   *  @param subPartitions Sub partitions based on which an Atum Context will be created or obtained.
+   *  @param parentAtumContext Parent AtumContext.
+   *  @return Atum context object
    */
   def getOrCreateAtumSubContext(subPartitions: AtumPartitions)(implicit parentAtumContext: AtumContext): AtumContext = {
     val authorIfNew = AtumAgent.currentUser

--- a/agent/src/main/scala/za/co/absa/atum/agent/AtumAgent.scala
+++ b/agent/src/main/scala/za/co/absa/atum/agent/AtumAgent.scala
@@ -18,7 +18,7 @@ package za.co.absa.atum.agent
 
 import com.typesafe.config.{Config, ConfigFactory}
 import za.co.absa.atum.agent.AtumContext.AtumPartitions
-import za.co.absa.atum.agent.dispatcher.{ConsoleDispatcher, HttpDispatcher}
+import za.co.absa.atum.agent.dispatcher.{CapturingDispatcher, ConsoleDispatcher, HttpDispatcher}
 import za.co.absa.atum.model.dto.{AdditionalDataSubmitDTO, CheckpointDTO, PartitioningSubmitDTO}
 
 /**
@@ -33,6 +33,7 @@ class AtumAgent private[agent] () {
   private val dispatcher = config.getString("atum.dispatcher.type") match {
     case "http" => new HttpDispatcher(config.getConfig("atum.dispatcher.http"))
     case "console" => new ConsoleDispatcher
+    case "capture" => CapturingDispatcher.fromConfig(config.getConfig("atum.dispatcher.capture"))
     case dt => throw new UnsupportedOperationException(s"Unsupported dispatcher type: '$dt''")
   }
 

--- a/agent/src/main/scala/za/co/absa/atum/agent/dispatcher/CapturingDispatcher.scala
+++ b/agent/src/main/scala/za/co/absa/atum/agent/dispatcher/CapturingDispatcher.scala
@@ -1,10 +1,26 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package za.co.absa.atum.agent.dispatcher
 
 import com.typesafe.config.Config
 import za.co.absa.atum.model.dto._
 
 import java.util
-import scala.jdk.CollectionConverters.IteratorHasAsScala
+import scala.jdk.CollectionConverters._
 
 /**
  *  This dispatcher instead of sending data captures them and stores them in memory.

--- a/agent/src/main/scala/za/co/absa/atum/agent/dispatcher/CapturingDispatcher.scala
+++ b/agent/src/main/scala/za/co/absa/atum/agent/dispatcher/CapturingDispatcher.scala
@@ -1,0 +1,123 @@
+package za.co.absa.atum.agent.dispatcher
+
+import com.typesafe.config.Config
+import za.co.absa.atum.model.dto._
+
+import java.util
+import scala.jdk.CollectionConverters.IteratorHasAsScala
+
+/**
+ *  This dispatcher instead of sending data captures them and stores them in memory.
+ *  @param checkpointsLimit maximal amount of checkpoints to be stored for each partition.
+ *                   If the limit is reached, the oldest checkpoint is removed.
+ *                   Value 0 removes this limit.
+ */
+class CapturingDispatcher(checkpointsLimit: Int) extends Dispatcher {
+  import CapturingDispatcher._
+
+  private val ts = util.Collections.synchronizedSortedMap(new util.TreeMap[String, PartitionedData]())
+
+  /**
+   *  This method is used to ensure the server knows the given partitioning.
+   *  As a response the `AtumContext` is fetched from the server.
+   *
+   *  @param partitioning  : PartitioningSubmitDTO to be used to ensure server knows the given partitioning.
+   *  @return AtumContextDTO.
+   */
+  override def createPartitioning(partitioning: PartitioningSubmitDTO): AtumContextDTO = {
+    AtumContextDTO(partitioning = partitioning.partitioning)
+  }
+
+  /**
+   *  This method is used to save checkpoint to server.
+   *
+   *  @param checkpoint : CheckpointDTO to be saved.
+   */
+  override def saveCheckpoint(checkpoint: CheckpointDTO): Unit = {
+    val path = createPath(checkpoint.partitioning)
+    ts.compute(
+      path,
+      (_, events) =>
+        Option(events)
+          .map(_.copy(checkpointStack = checkpoint :: takeLatestCheckpoints(events.checkpointStack)))
+          .getOrElse(PartitionedData(path, checkpoint :: Nil, Map.empty))
+    )
+  }
+
+  private def takeLatestCheckpoints(list: List[CheckpointDTO]): List[CheckpointDTO] = {
+    if (checkpointsLimit <= 0) list
+    else if (checkpointsLimit == 1) Nil
+    else if (checkpointsLimit > list.size) list
+    else list.take(checkpointsLimit - 1)
+  }
+
+  /**
+   *  This method is used to save the additional data to the server.
+   *
+   *  @param additionalData the data to be saved.
+   */
+  override def saveAdditionalData(additionalData: AdditionalDataSubmitDTO): Unit = {
+    val path = createPath(additionalData.partitioning)
+    ts.compute(
+      path,
+      (_, events) =>
+        Option(events)
+          .map(_.copy(additionalData = additionalData.additionalData))
+          .getOrElse(PartitionedData(path, Nil, additionalData.additionalData))
+    )
+  }
+
+  /**
+   *  This method is used to clear all captured data.
+   */
+  def clear(): Unit = ts.clear()
+
+  /**
+   *  This method creates iterator iterating over all captured data with specified prefix.
+   */
+  def prefixIter(prefix: String): Iterator[PartitionedData] = {
+    val prefixWithSlash = sanitizeKey(prefix)
+    ts.tailMap(prefixWithSlash)
+      .entrySet()
+      .iterator()
+      .asScala
+      .takeWhile(_.getKey.startsWith(prefixWithSlash))
+      .map(_.getValue)
+  }
+
+  /**
+   *  This method is used to get the partitioned data for the given key.
+   *
+   *  @param key the key of the partitioned data. This key will be wrapped in `/` if it's not already.
+   *             If the key is empty or null, the root partition will be returned.
+   *  @return the partitioned data
+   */
+  def getPartition(key: String): Option[PartitionedData] = {
+    Option(ts.get(sanitizeKey(key)))
+  }
+}
+
+object CapturingDispatcher {
+  private val CheckpointLimitKey = "checkpoints-limit"
+  def fromConfig(config: Config): CapturingDispatcher =
+    new CapturingDispatcher(config.getInt(CheckpointLimitKey))
+
+  case class PartitionedData(
+    partition: String,
+    checkpointStack: List[CheckpointDTO],
+    additionalData: Map[String, Option[String]]
+  ) {
+    def checkpoints: List[CheckpointDTO] = checkpointStack.reverse
+  }
+
+  private def createPath(partitioning: PartitioningDTO): String =
+    partitioning.map(p => s"${p.key}=${p.value}").mkString(start = "/", sep = "/", end = "/")
+
+  private def sanitizeKey(prefix: String): String = {
+    if (prefix == null || prefix.isEmpty) "/"
+    else {
+      val withLeadingSlash = if (prefix.startsWith("/")) prefix else s"/$prefix"
+      if (withLeadingSlash.endsWith("/")) withLeadingSlash else s"$withLeadingSlash/"
+    }
+  }
+}

--- a/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentTest.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentTest.scala
@@ -22,7 +22,7 @@ import za.co.absa.atum.agent.AtumContext.AtumPartitions
 class AtumAgentTest extends AnyFunSuiteLike {
 
   test("AtumAgent creates AtumContext(s) as expected") {
-    val atumAgent = new AtumAgent()
+    val atumAgent = AtumAgent
     val atumPartitions = AtumPartitions("abc" -> "def")
     val subPartitions = AtumPartitions("ghi", "jkl")
 

--- a/agent/src/test/scala/za/co/absa/atum/agent/AtumContextTest.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/AtumContextTest.scala
@@ -188,7 +188,7 @@ class AtumContextTest extends AnyFlatSpec with Matchers {
   }
 
   "addAdditionalData" should "add key/value pair to map for additional data" in {
-    val atumAgent = new AtumAgent
+    val atumAgent = AtumAgent
     val atumPartitions = AtumPartitions("key" -> "val")
     val atumContext = atumAgent.getOrCreateAtumContext(atumPartitions)
 

--- a/agent/src/test/scala/za/co/absa/atum/agent/dispatcher/CapturingDispatcherTest.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/dispatcher/CapturingDispatcherTest.scala
@@ -110,7 +110,7 @@ class CapturingDispatcherTest extends AnyFlatSpec with Matchers {
 
     val it = underTest.prefixIter("/")
 
-    var idx = 0;
+    var idx = 0
     var collected = List.empty[String]
 
     assertThrows[ConcurrentModificationException] {
@@ -210,7 +210,7 @@ class CapturingDispatcherTest extends AnyFlatSpec with Matchers {
     )
 
   private def createPartition(kvs: (String, String)*): PartitioningDTO = {
-    kvs.map { case (k, v) => PartitionDTO(k, v) }.toSeq
+    kvs.map { case (k, v) => PartitionDTO(k, v) }
   }
 
 }

--- a/agent/src/test/scala/za/co/absa/atum/agent/dispatcher/CapturingDispatcherTest.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/dispatcher/CapturingDispatcherTest.scala
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package za.co.absa.atum.agent.dispatcher
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import za.co.absa.atum.agent.dispatcher.CapturingDispatcher.PartitionedData
-import za.co.absa.atum.model.dto.{AdditionalDataSubmitDTO, CheckpointDTO, MeasurementDTO, PartitionDTO, PartitioningDTO}
+import za.co.absa.atum.model.dto.{AdditionalDataSubmitDTO, CheckpointDTO, PartitionDTO, PartitioningDTO}
 
 import java.time.ZonedDateTime
 import java.util.{ConcurrentModificationException, UUID}

--- a/agent/src/test/scala/za/co/absa/atum/agent/dispatcher/CapturingDispatcherTest.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/dispatcher/CapturingDispatcherTest.scala
@@ -1,0 +1,216 @@
+package za.co.absa.atum.agent.dispatcher
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.atum.agent.dispatcher.CapturingDispatcher.PartitionedData
+import za.co.absa.atum.model.dto.{AdditionalDataSubmitDTO, CheckpointDTO, MeasurementDTO, PartitionDTO, PartitioningDTO}
+
+import java.time.ZonedDateTime
+import java.util.{ConcurrentModificationException, UUID}
+
+class CapturingDispatcherTest extends AnyFlatSpec with Matchers {
+  private val DefaultProcessStartTime = ZonedDateTime.parse("2024-03-11T00:00:00Z")
+
+  "saveAdditionalData" should "capture and store additionalData" in {
+    val underTest = new CapturingDispatcher(10)
+    underTest.saveAdditionalData(
+      AdditionalDataSubmitDTO(createPartition("k1" -> "v1", "k2" -> "v2"), Map("opt1" -> Some("v1")))
+    )
+
+    underTest.getPartition("/k1=v1/k2=v2/") shouldBe Some(
+      PartitionedData("/k1=v1/k2=v2/", Nil, Map("opt1" -> Some("v1")))
+    )
+  }
+
+  it should "overwrite the saved additionalDate" in {
+    val underTest = new CapturingDispatcher(10)
+    underTest.saveAdditionalData(
+      AdditionalDataSubmitDTO(createPartition("k1" -> "v1", "k2" -> "v2"), Map("opt1" -> Some("v1")))
+    )
+    underTest.saveAdditionalData(
+      AdditionalDataSubmitDTO(createPartition("k1" -> "v1", "k2" -> "v2"), Map("opt1" -> Some("v2")))
+    )
+
+    underTest.getPartition("/k1=v1/k2=v2/") shouldBe Some(
+      PartitionedData("/k1=v1/k2=v2/", Nil, Map("opt1" -> Some("v2")))
+    )
+  }
+
+  "saveCheckpoint" should "capture and store checkpoint" in {
+    val underTest = new CapturingDispatcher(0)
+    val checkpoint = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    underTest.saveCheckpoint(checkpoint)
+
+    underTest.getPartition("/k1=v1/k2=v2/") shouldBe Some(
+      PartitionedData("/k1=v1/k2=v2/", List(checkpoint), Map.empty)
+    )
+  }
+
+  it should "capture all checkpoints when limit is set to 0" in {
+    val underTest = new CapturingDispatcher(0)
+    val checkpoint1 = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    val checkpoint2 = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    val checkpoint3 = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    val checkpoint4 = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    val checkpoint5 = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    underTest.saveCheckpoint(checkpoint1)
+    underTest.saveCheckpoint(checkpoint2)
+    underTest.saveCheckpoint(checkpoint3)
+    underTest.saveCheckpoint(checkpoint4)
+    underTest.saveCheckpoint(checkpoint5)
+
+    underTest.getPartition("/k1=v1/k2=v2/") shouldBe Some(
+      PartitionedData("/k1=v1/k2=v2/", List(checkpoint5, checkpoint4, checkpoint3, checkpoint2, checkpoint1), Map.empty)
+    )
+  }
+
+  it should "store the same checkpoint multiple times" in {
+    val underTest = new CapturingDispatcher(0)
+    val checkpoint = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    underTest.saveCheckpoint(checkpoint)
+    underTest.saveCheckpoint(checkpoint)
+
+    underTest.getPartition("/k1=v1/k2=v2/") shouldBe Some(
+      PartitionedData("/k1=v1/k2=v2/", List(checkpoint, checkpoint), Map.empty)
+    )
+  }
+
+  it should "prepend checkpoint to the same partition" in {
+    val underTest = new CapturingDispatcher(10)
+    val checkpoint1 = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    val checkpoint2 = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    underTest.saveCheckpoint(checkpoint1)
+    underTest.saveCheckpoint(checkpoint2)
+
+    underTest.getPartition("/k1=v1/k2=v2/") shouldBe Some(
+      PartitionedData("/k1=v1/k2=v2/", List(checkpoint2, checkpoint1), Map.empty)
+    )
+  }
+
+  it should "keep only the max number of checkpoints" in {
+    val underTest = new CapturingDispatcher(2)
+    val checkpoint1 = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    val checkpoint2 = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    val checkpoint3 = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    underTest.saveCheckpoint(checkpoint1)
+    underTest.saveCheckpoint(checkpoint2)
+    underTest.saveCheckpoint(checkpoint3)
+
+    underTest.getPartition("/k1=v1/k2=v2/") shouldBe Some(
+      PartitionedData("/k1=v1/k2=v2/", List(checkpoint3, checkpoint2), Map.empty)
+    )
+  }
+
+  it should "raise an exception on concurrent modification attempt" in {
+    val underTest = new CapturingDispatcher(1)
+    val checkpoint1 = createCheckpoint(createPartition("k1" -> "v1"))
+    val checkpoint2 = createCheckpoint(createPartition("k1" -> "v2"))
+    underTest.saveCheckpoint(checkpoint1)
+    underTest.saveCheckpoint(checkpoint2)
+
+    val it = underTest.prefixIter("/")
+
+    var idx = 0;
+    var collected = List.empty[String]
+
+    assertThrows[ConcurrentModificationException] {
+      while (it.hasNext) {
+        if (idx == 0) {
+          underTest.saveCheckpoint(createCheckpoint(createPartition("k1" -> "v3")))
+        }
+        idx += 1
+        collected = it.next().partition :: collected
+      }
+    }
+  }
+
+  "clear" should "remove all persisted partitions" in {
+    val underTest = new CapturingDispatcher(10)
+    val checkpoint = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    underTest.saveCheckpoint(checkpoint)
+    underTest.clear()
+
+    underTest.prefixIter("").toList shouldBe Nil
+  }
+
+  "prefixIter" should "return all partitions with the given prefix" in {
+    val underTest = new CapturingDispatcher(10)
+    val checkpoint1 = createCheckpoint(createPartition("k1" -> "v1"))
+    val checkpoint2 = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    val checkpoint3 = createCheckpoint(createPartition("k1" -> "w1", "k2" -> "v2"))
+    underTest.saveCheckpoint(checkpoint1)
+    underTest.saveCheckpoint(checkpoint2)
+    underTest.saveCheckpoint(checkpoint3)
+
+    underTest.prefixIter("/k1=v1/").toList shouldBe List(
+      PartitionedData("/k1=v1/", List(checkpoint1), Map.empty),
+      PartitionedData("/k1=v1/k2=v2/", List(checkpoint2), Map.empty)
+    )
+  }
+
+  it should "return every partition for empty prefix" in {
+    val underTest = new CapturingDispatcher(10)
+    val checkpoint1 = createCheckpoint(createPartition("k1" -> "v1"))
+    val checkpoint2 = createCheckpoint(createPartition("k1" -> "v1", "k2" -> "v2"))
+    val checkpoint3 = createCheckpoint(createPartition("k1" -> "v2", "k2" -> "v2"))
+    underTest.saveCheckpoint(checkpoint1)
+    underTest.saveCheckpoint(checkpoint2)
+    underTest.saveCheckpoint(checkpoint3)
+
+    underTest.prefixIter("").toList shouldBe List(
+      PartitionedData("/k1=v1/", List(checkpoint1), Map.empty),
+      PartitionedData("/k1=v1/k2=v2/", List(checkpoint2), Map.empty),
+      PartitionedData("/k1=v2/k2=v2/", List(checkpoint3), Map.empty)
+    )
+  }
+
+  it should "return partitions ordered alphanumerically" in {
+    val underTest = new CapturingDispatcher(10)
+    val checkpoint1 = createCheckpoint(createPartition("k1" -> "a"))
+    val checkpoint2 = createCheckpoint(createPartition("k1" -> "a", "k2" -> "A"))
+    val checkpoint3 = createCheckpoint(createPartition("k1" -> "a", "k2" -> "1"))
+    val checkpoint4 = createCheckpoint(createPartition("k1" -> "a", "k2" -> "a"))
+    val checkpoint5 = createCheckpoint(createPartition("k2" -> "a"))
+    underTest.saveCheckpoint(checkpoint1)
+    underTest.saveCheckpoint(checkpoint2)
+    underTest.saveCheckpoint(checkpoint3)
+    underTest.saveCheckpoint(checkpoint4)
+    underTest.saveCheckpoint(checkpoint5)
+
+    underTest.prefixIter("").map(_.partition).toList shouldBe List(
+      "/k1=a/",
+      "/k1=a/k2=1/",
+      "/k1=a/k2=A/",
+      "/k1=a/k2=a/",
+      "/k2=a/"
+    )
+  }
+
+  "PartitionedData.checkpoints" should "retain the checkpoint save order" in {
+    val underTest = new CapturingDispatcher(10)
+    val checkpoint1 = createCheckpoint(createPartition("k1" -> "v1"))
+    val checkpoint2 = createCheckpoint(createPartition("k1" -> "v1"))
+    val checkpoint3 = createCheckpoint(createPartition("k1" -> "v1"))
+    underTest.saveCheckpoint(checkpoint1)
+    underTest.saveCheckpoint(checkpoint2)
+    underTest.saveCheckpoint(checkpoint3)
+
+    underTest.getPartition("/k1=v1/").map(_.checkpoints) shouldBe Some(List(checkpoint1, checkpoint2, checkpoint3))
+  }
+
+  private def createCheckpoint(partition: PartitioningDTO): CheckpointDTO =
+    CheckpointDTO(
+      id = UUID.randomUUID(),
+      name = "name",
+      author = "author",
+      partitioning = partition,
+      processStartTime = DefaultProcessStartTime,
+      processEndTime = None,
+      measurements = Set.empty
+    )
+
+  private def createPartition(kvs: (String, String)*): PartitioningDTO = {
+    kvs.map { case (k, v) => PartitionDTO(k, v) }.toSeq
+  }
+
+}


### PR DESCRIPTION
Simplify writing tests for atum agent

There is an option to configure it:
```hocon
atum.dispatcher.type = "capture"
atum.dispatcher.capture = {
  checkpoints-limit = 100
}
```

But most likely here is how it would be used
```scala
// za.co.absa.atum.agent
// imports ...
class TestAgent(disp: Dispatcher) extends AtumAgent {
  override val dispatcher: Dispatcher = disp
}

// in pramen sink
class AtumSink(agent: AtumAgent, ...) extends Sink {...}

new AtumSink(AtumAgent, ...)

// in tests
val cd = new CapturingDispatcher(0)
val agent = new TestAgent(cd)
val underTest = new AtumSink(agent, ...)

underTest.send(...)

cd.getPartition("key1=value1/key2=value2/key3=value3").checkpoints.size shouldBe 3
```