### PR TITLE
#285: Atum Release 0.3.0 - script downgrade

### DIFF
--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -108,7 +108,7 @@ jobs:
           ref: refs/tags/${{ github.event.inputs.tagName }}
       - name: Generate release notes
         id: generate_release_notes
-        uses: AbsaOSS/generate-release-notes@feature/55-Chapter-line-formatting-authors
+        uses: AbsaOSS/generate-release-notes@v0.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
*  AbsaOSS/generate-release-notes downgraded to released version from a development branch

Eventually #285
