### PR TITLE
Implemented the server portion of the `PartitioningParentPatch`

### DIFF
--- a/model/src/main/scala/za/co/absa/atum/model/ApiPaths.scala
+++ b/model/src/main/scala/za/co/absa/atum/model/ApiPaths.scala
@@ -40,6 +40,7 @@ object ApiPaths {
     final val Flows = "flows"
     final val Measures = "measures"
     final val MainFlow = "main-flow"
+    final val Ancestors = "ancestors"
 
   }
 

--- a/model/src/main/scala/za/co/absa/atum/model/dto/PartitioningParentPatchDTO.scala
+++ b/model/src/main/scala/za/co/absa/atum/model/dto/PartitioningParentPatchDTO.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.atum.model.dto
+
+import io.circe._
+import io.circe.generic.semiauto._
+
+case class PartitioningParentPatchDTO(
+  parentPartitioningId: Long,
+  author: String,
+  copyMeasurements: Boolean = true,
+  copyAdditionalData: Boolean = true
+)
+
+object PartitioningParentPatchDTO {
+  implicit val decodePartitioningParentPatchDTO: Decoder[PartitioningParentPatchDTO] = deriveDecoder
+  implicit val encodePartitioningParentPatchDTO: Encoder[PartitioningParentPatchDTO] = deriveEncoder
+}

--- a/server/src/main/scala/za/co/absa/atum/server/Main.scala
+++ b/server/src/main/scala/za/co/absa/atum/server/Main.scala
@@ -66,6 +66,7 @@ object Main extends ZIOAppDefault with Server {
           GetPartitioning.layer,
           GetFlowPartitionings.layer,
           GetPartitioningMainFlow.layer,
+          UpdatePartitioningParent.layer,
           PostgresDatabaseProvider.layer,
           TransactorProvider.layer,
           AwsSecretsProviderImpl.layer,

--- a/server/src/main/scala/za/co/absa/atum/server/api/controller/PartitioningController.scala
+++ b/server/src/main/scala/za/co/absa/atum/server/api/controller/PartitioningController.scala
@@ -60,4 +60,10 @@ trait PartitioningController {
   def getPartitioningMainFlow(
     partitioningId: Long
   ): IO[ErrorResponse, SingleSuccessResponse[FlowDTO]]
+
+  def patchPartitioningParent(
+    partitioningId: Long,
+    partitioningParentPatchDTO: PartitioningParentPatchDTO
+  ): IO[ErrorResponse, SingleSuccessResponse[PartitioningParentPatchDTO]]
+
 }

--- a/server/src/main/scala/za/co/absa/atum/server/api/controller/PartitioningControllerImpl.scala
+++ b/server/src/main/scala/za/co/absa/atum/server/api/controller/PartitioningControllerImpl.scala
@@ -160,6 +160,17 @@ class PartitioningControllerImpl(partitioningService: PartitioningService)
     )
   }
 
+  override def patchPartitioningParent(
+    partitioningId: Long,
+    partitioningParentPatchDTO: PartitioningParentPatchDTO
+  ): IO[ErrorResponse, SingleSuccessResponse[PartitioningParentPatchDTO]] = {
+    mapToSingleSuccessResponse(
+        serviceCall[Unit, PartitioningParentPatchDTO](
+          partitioningService.patchPartitioningParent(partitioningId, partitioningParentPatchDTO),
+          _ => partitioningParentPatchDTO
+        )
+      )
+  }
 }
 
 object PartitioningControllerImpl {

--- a/server/src/main/scala/za/co/absa/atum/server/api/database/runs/functions/UpdatePartitioningParent.scala
+++ b/server/src/main/scala/za/co/absa/atum/server/api/database/runs/functions/UpdatePartitioningParent.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.atum.server.api.database.runs.functions
+
+import doobie.implicits.toSqlInterpolator
+import io.circe.syntax._
+import za.co.absa.atum.model.dto.PartitioningParentPatchDTO
+import za.co.absa.atum.server.api.database.PostgresDatabaseProvider
+import za.co.absa.atum.server.api.database.runs.Runs
+import za.co.absa.atum.server.api.database.runs.functions.UpdatePartitioningParent.UpdatePartitioningParentArgs
+import za.co.absa.db.fadb.DBSchema
+import za.co.absa.db.fadb.doobie.DoobieEngine
+import za.co.absa.db.fadb.doobie.DoobieFunction.DoobieSingleResultFunctionWithStatus
+import za.co.absa.db.fadb.status.handling.implementations.StandardStatusHandling
+import zio._
+
+class UpdatePartitioningParent(implicit schema: DBSchema, dbEngine: DoobieEngine[Task])
+    extends DoobieSingleResultFunctionWithStatus[UpdatePartitioningParentArgs, Unit, Task](args =>
+      Seq(
+        fr"${args.partitioningId}",
+        fr"${args.partitioningParentPatchDTO.parentPartitioningId}",
+        fr"${args.partitioningParentPatchDTO.author}",
+        fr"${args.partitioningParentPatchDTO.copyMeasurements}",
+        fr"${args.partitioningParentPatchDTO.copyAdditionalData}",
+      ),
+      Some("update_partitioning_parent")
+    )
+    with StandardStatusHandling
+
+object UpdatePartitioningParent {
+  case class UpdatePartitioningParentArgs(
+    partitioningId: Long,
+    partitioningParentPatchDTO: PartitioningParentPatchDTO
+ )
+
+  val layer: URLayer[PostgresDatabaseProvider, UpdatePartitioningParent] = ZLayer {
+    for {
+      dbProvider <- ZIO.service[PostgresDatabaseProvider]
+    } yield new UpdatePartitioningParent()(Runs, dbProvider.dbEngine)
+  }
+}

--- a/server/src/main/scala/za/co/absa/atum/server/api/http/Endpoints.scala
+++ b/server/src/main/scala/za/co/absa/atum/server/api/http/Endpoints.scala
@@ -185,6 +185,17 @@ trait Endpoints extends BaseEndpoints {
       .errorOutVariantPrepend(errorInDataOneOfVariant)
   }
 
+  protected val patchPartitioningParentEndpointV2
+  : PublicEndpoint[(Long, PartitioningParentPatchDTO), ErrorResponse, SingleSuccessResponse[PartitioningParentPatchDTO], Any] = {
+    apiV2.patch
+      .in(V2Paths.Partitionings / path[Long]("partitioningId") / V2Paths.Ancestors)
+      .in(jsonBody[PartitioningParentPatchDTO])
+      .out(statusCode(StatusCode.Ok))
+      .out(jsonBody[SingleSuccessResponse[PartitioningParentPatchDTO]])
+      .errorOutVariantPrepend(conflictErrorOneOfVariant)
+      .errorOutVariantPrepend(notFoundErrorOneOfVariant)
+  }
+
   protected val zioMetricsEndpoint: PublicEndpoint[Unit, Unit, String, Any] = {
     endpoint.get.in(ZioMetrics).out(stringBody)
   }

--- a/server/src/main/scala/za/co/absa/atum/server/api/http/Routes.scala
+++ b/server/src/main/scala/za/co/absa/atum/server/api/http/Routes.scala
@@ -24,7 +24,7 @@ import sttp.tapir.server.http4s.ztapir.ZHttp4sServerInterpreter
 import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import sttp.tapir.ztapir._
-import za.co.absa.atum.model.dto.{AdditionalDataDTO, AdditionalDataPatchDTO, CheckpointV2DTO, CheckpointWithPartitioningDTO, PartitioningWithIdDTO}
+import za.co.absa.atum.model.dto.{AdditionalDataDTO, AdditionalDataPatchDTO, CheckpointV2DTO, CheckpointWithPartitioningDTO, PartitioningParentPatchDTO, PartitioningWithIdDTO}
 import za.co.absa.atum.model.envelopes.{ErrorResponse, StatusResponse}
 import za.co.absa.atum.server.api.controller.{CheckpointController, FlowController, PartitioningController}
 import za.co.absa.atum.server.config.{HttpMonitoringConfig, JvmMonitoringConfig}
@@ -111,6 +111,16 @@ trait Routes extends Endpoints with ServerOptions {
           PartitioningController.getFlowPartitionings(flowId, limit, offset)
         }
       ),
+      createServerEndpoint[
+        (Long, PartitioningParentPatchDTO),
+        ErrorResponse,
+        SingleSuccessResponse[PartitioningParentPatchDTO]
+      ](
+        patchPartitioningParentEndpointV2,
+        { case (partitioningId: Long, partitioningParentPatchDTO: PartitioningParentPatchDTO) =>
+          PartitioningController.patchPartitioningParent(partitioningId, partitioningParentPatchDTO)
+        }
+      ),
       createServerEndpoint(healthEndpoint, (_: Unit) => ZIO.succeed(StatusResponse.up))
     )
     ZHttp4sServerInterpreter[HttpEnv.Env](http4sServerOptions(metricsInterceptorOption)).from(endpoints).toRoutes
@@ -134,6 +144,7 @@ trait Routes extends Endpoints with ServerOptions {
       getFlowPartitioningsEndpointV2,
       getPartitioningMainFlowEndpointV2,
       getFlowCheckpointsEndpointV2,
+      patchPartitioningParentEndpointV2,
       healthEndpoint
     )
     ZHttp4sServerInterpreter[HttpEnv.Env](http4sServerOptions(None))

--- a/server/src/main/scala/za/co/absa/atum/server/api/repository/PartitioningRepository.scala
+++ b/server/src/main/scala/za/co/absa/atum/server/api/repository/PartitioningRepository.scala
@@ -56,4 +56,9 @@ trait PartitioningRepository {
   ): IO[DatabaseError, PaginatedResult[PartitioningWithIdDTO]]
 
   def getPartitioningMainFlow(partitioningId: Long): IO[DatabaseError, FlowDTO]
+
+  def updatePartitioningParent(
+    partitioningId: Long,
+    partitioningParentPatchDTO: PartitioningParentPatchDTO
+  ): IO[DatabaseError, Unit]
 }

--- a/server/src/main/scala/za/co/absa/atum/server/api/repository/PartitioningRepositoryImpl.scala
+++ b/server/src/main/scala/za/co/absa/atum/server/api/repository/PartitioningRepositoryImpl.scala
@@ -19,6 +19,7 @@ package za.co.absa.atum.server.api.repository
 import za.co.absa.atum.model.dto._
 import za.co.absa.atum.server.api.database.flows.functions.GetFlowPartitionings._
 import za.co.absa.atum.server.api.database.runs.functions.CreateOrUpdateAdditionalData.CreateOrUpdateAdditionalDataArgs
+import za.co.absa.atum.server.api.database.runs.functions.UpdatePartitioningParent.UpdatePartitioningParentArgs
 import za.co.absa.atum.server.api.database.runs.functions._
 import za.co.absa.atum.server.api.database.flows.functions._
 import za.co.absa.atum.server.api.exception.DatabaseError
@@ -38,7 +39,8 @@ class PartitioningRepositoryImpl(
   getPartitioningMeasuresByIdFn: GetPartitioningMeasuresById,
   getPartitioningFn: GetPartitioning,
   getFlowPartitioningsFn: GetFlowPartitionings,
-  getPartitioningMainFlowFn: GetPartitioningMainFlow
+  getPartitioningMainFlowFn: GetPartitioningMainFlow,
+  updatePartitioningParentFn: UpdatePartitioningParent
 ) extends PartitioningRepository
     with BaseRepository {
 
@@ -158,6 +160,15 @@ class PartitioningRepositoryImpl(
     }
   }
 
+  override def updatePartitioningParent(
+    partitioningId: Long,
+    partitioningParentPatchDTO: PartitioningParentPatchDTO
+    ): IO[DatabaseError, Unit] = {
+    dbSingleResultCallWithStatus(
+      updatePartitioningParentFn(UpdatePartitioningParentArgs(partitioningId, partitioningParentPatchDTO)),
+      "updatePartitioningParent"
+    )
+  }
 }
 
 object PartitioningRepositoryImpl {
@@ -171,7 +182,8 @@ object PartitioningRepositoryImpl {
       with GetPartitioningMeasuresById
       with GetPartitioning
       with GetFlowPartitionings
-      with GetPartitioningMainFlow,
+      with GetPartitioningMainFlow
+      with UpdatePartitioningParent,
     PartitioningRepository
   ] = ZLayer {
     for {
@@ -185,6 +197,7 @@ object PartitioningRepositoryImpl {
       getPartitioning <- ZIO.service[GetPartitioning]
       getFlowPartitionings <- ZIO.service[GetFlowPartitionings]
       getPartitioningMainFlow <- ZIO.service[GetPartitioningMainFlow]
+      updatePartitioningParent <- ZIO.service[UpdatePartitioningParent]
     } yield new PartitioningRepositoryImpl(
       createPartitioningIfNotExists,
       createPartitioning,
@@ -195,7 +208,8 @@ object PartitioningRepositoryImpl {
       getPartitioningMeasuresById,
       getPartitioning,
       getFlowPartitionings,
-      getPartitioningMainFlow
+      getPartitioningMainFlow,
+      updatePartitioningParent
     )
   }
 

--- a/server/src/main/scala/za/co/absa/atum/server/api/service/PartitioningService.scala
+++ b/server/src/main/scala/za/co/absa/atum/server/api/service/PartitioningService.scala
@@ -54,4 +54,9 @@ trait PartitioningService {
   ): IO[ServiceError, PaginatedResult[PartitioningWithIdDTO]]
 
   def getPartitioningMainFlow(partitioningId: Long): IO[ServiceError, FlowDTO]
+
+  def patchPartitioningParent(
+    partitioningId: Long,
+    partitioningParentPatchDTO: PartitioningParentPatchDTO
+  ): IO[ServiceError, Unit]
 }

--- a/server/src/main/scala/za/co/absa/atum/server/api/service/PartitioningServiceImpl.scala
+++ b/server/src/main/scala/za/co/absa/atum/server/api/service/PartitioningServiceImpl.scala
@@ -104,6 +104,15 @@ class PartitioningServiceImpl(partitioningRepository: PartitioningRepository)
     )
   }
 
+  override def patchPartitioningParent(
+    partitioningId: Long,
+    partitioningParentPatchDTO: PartitioningParentPatchDTO
+  ): IO[ServiceError, Unit] = {
+    repositoryCall(
+      partitioningRepository.updatePartitioningParent(partitioningId, partitioningParentPatchDTO),
+      "updatePartitioningParent"
+    )
+  }
 }
 
 object PartitioningServiceImpl {

--- a/server/src/test/scala/za/co/absa/atum/server/api/TestData.scala
+++ b/server/src/test/scala/za/co/absa/atum/server/api/TestData.scala
@@ -249,6 +249,25 @@ trait TestData {
     checkpointName = None
   )
 
+  // PartitioningParentPatch DTO
+  protected val partitioningParentPatchDTO1: PartitioningParentPatchDTO = PartitioningParentPatchDTO(
+    parentPartitioningId = 1L,
+    author = "author"
+  )
+
+  protected val partitioningParentPatchDTO2: PartitioningParentPatchDTO = PartitioningParentPatchDTO(
+    parentPartitioningId = 2L,
+    author = "author2"
+  )
+
+  protected val partitioningParentPatchDTO3: PartitioningParentPatchDTO = partitioningParentPatchDTO1.copy(author = "differentAuthor")
+  protected val partitioningParentPatchDTO4: PartitioningParentPatchDTO = partitioningParentPatchDTO1.copy(author = "yetAnotherAuthor")
+
+  protected val partitioningParentPatchDTO5: PartitioningParentPatchDTO = PartitioningParentPatchDTO(
+    parentPartitioningId = 0L,
+    author = "NoParent"
+  )
+
   // Checkpoint DTO
   protected val checkpointDTO1: CheckpointDTO = CheckpointDTO(
     id = UUID.randomUUID(),

--- a/server/src/test/scala/za/co/absa/atum/server/api/controller/PartitioningControllerUnitTests.scala
+++ b/server/src/test/scala/za/co/absa/atum/server/api/controller/PartitioningControllerUnitTests.scala
@@ -90,6 +90,19 @@ object PartitioningControllerUnitTests extends ZIOSpecDefault with TestData {
   when(partitioningServiceMock.getPartitioningMainFlow(999L))
     .thenReturn(ZIO.fail(GeneralServiceError("boom!")))
 
+  private val partitioningId1 = 1L
+
+  when(partitioningServiceMock.patchPartitioningParent(partitioningId1, partitioningParentPatchDTO1))
+    .thenReturn(ZIO.unit)
+  when(partitioningServiceMock.patchPartitioningParent(partitioningId1, partitioningParentPatchDTO2))
+    .thenReturn(ZIO.fail(GeneralServiceError("error in data")))
+  when(partitioningServiceMock.patchPartitioningParent(partitioningId1, partitioningParentPatchDTO3))
+    .thenReturn(ZIO.fail(ConflictServiceError("boom!")))
+  when(partitioningServiceMock.patchPartitioningParent(1L, partitioningParentPatchDTO5))
+    .thenReturn(ZIO.fail(NotFoundServiceError("Parent Partitioning not found")))
+  when(partitioningServiceMock.patchPartitioningParent(0L, partitioningParentPatchDTO3))
+    .thenReturn(ZIO.fail(NotFoundServiceError("Child Partitioning not found")))
+
   private val partitioningServiceMockLayer = ZLayer.succeed(partitioningServiceMock)
 
   override def spec: Spec[TestEnvironment with Scope, Any] = {
@@ -143,6 +156,35 @@ object PartitioningControllerUnitTests extends ZIOSpecDefault with TestData {
         test("Returns expected InternalServerErrorResponse") {
           assertZIO(PartitioningController.patchPartitioningAdditionalDataV2(2L, additionalDataPatchDTO1).exit)(
             failsWithA[InternalServerErrorResponse]
+          )
+        }
+      ),
+      suite("PatchPartitioningParentSuite")(
+        test("Returns expected PartitioningParentPatchDTO") {
+          for {
+            result <- PartitioningController.patchPartitioningParent(partitioningId1, partitioningParentPatchDTO1)
+            expected = SingleSuccessResponse(partitioningParentPatchDTO1, uuid1)
+            actual = result.copy(requestId = uuid1)
+          } yield assertTrue(actual == expected)
+        },
+        test("Returns expected InternalServerErrorResponse") {
+          assertZIO(PartitioningController.patchPartitioningParent(partitioningId1, partitioningParentPatchDTO2).exit)(
+            failsWithA[InternalServerErrorResponse]
+          )
+        },
+        test("Returns expected ConflictServiceError") {
+          assertZIO(PartitioningController.patchPartitioningParent(partitioningId1, partitioningParentPatchDTO3).exit)(
+            failsWithA[ConflictErrorResponse]
+          )
+        },
+        test("Returns expected NotFoundErrorResponse") {
+          assertZIO(PartitioningController.patchPartitioningParent(1L, partitioningParentPatchDTO5).exit)(
+            failsWithA[NotFoundErrorResponse]
+          )
+        },
+        test("Returns expected NotFoundErrorResponse") {
+          assertZIO(PartitioningController.patchPartitioningParent(0L, partitioningParentPatchDTO3).exit)(
+            failsWithA[NotFoundErrorResponse]
           )
         }
       ),

--- a/server/src/test/scala/za/co/absa/atum/server/api/database/runs/functions/UpdatePartitioningParentIntegrationTests.scala
+++ b/server/src/test/scala/za/co/absa/atum/server/api/database/runs/functions/UpdatePartitioningParentIntegrationTests.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.atum.server.api.database.runs.functions
+
+import za.co.absa.atum.model.dto._
+import za.co.absa.atum.server.ConfigProviderTest
+import za.co.absa.atum.server.api.TestTransactorProvider
+import za.co.absa.atum.server.api.database.PostgresDatabaseProvider
+import za.co.absa.atum.server.api.database.runs.functions.UpdatePartitioningParent.UpdatePartitioningParentArgs
+import za.co.absa.db.fadb.exceptions.DataNotFoundException
+import za.co.absa.db.fadb.status.FunctionStatus
+import zio._
+import zio.interop.catz.asyncInstance
+import zio.test._
+
+object UpdatePartitioningParentIntegrationTests extends ConfigProviderTest {
+
+  override def spec: Spec[TestEnvironment with Scope, Any] = {
+
+    suite("UpdatePartitioningParentSuite")(
+      test("Returns expected Left with DataNotFoundException as related partitioning is not in the database") {
+        val partitioningParentPatchDTO = PartitioningParentPatchDTO(
+          parentPartitioningId = 2L,
+          author = "author")
+        for {
+          updatePartitioningParent <- ZIO.service[UpdatePartitioningParent]
+          result <- updatePartitioningParent(UpdatePartitioningParentArgs(1L, partitioningParentPatchDTO))
+        } yield assertTrue(result == Left(DataNotFoundException(FunctionStatus(41, "Child Partitioning not found"))))
+      }
+    ).provide(
+      UpdatePartitioningParent.layer,
+      PostgresDatabaseProvider.layer,
+      TestTransactorProvider.layerWithRollback
+    )
+  }
+
+
+}

--- a/server/src/test/scala/za/co/absa/atum/server/api/http/PatchPartitioningParentEndpointUnitTests.scala
+++ b/server/src/test/scala/za/co/absa/atum/server/api/http/PatchPartitioningParentEndpointUnitTests.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.atum.server.api.http
+
+import io.circe
+import org.mockito.Mockito.{mock, when}
+import sttp.client3.circe._
+import sttp.client3.testing.SttpBackendStub
+import sttp.client3.{Identity, RequestT, ResponseException, UriContext, basicRequest}
+import sttp.model.StatusCode
+import sttp.tapir.server.stub.TapirStubInterpreter
+import sttp.tapir.ztapir.{RIOMonadError, RichZEndpoint}
+import za.co.absa.atum.model.dto.PartitioningParentPatchDTO
+import za.co.absa.atum.model.envelopes.SuccessResponse.SingleSuccessResponse
+import za.co.absa.atum.model.envelopes.{ConflictErrorResponse, GeneralErrorResponse, InternalServerErrorResponse, NotFoundErrorResponse}
+import za.co.absa.atum.server.api.TestData
+import za.co.absa.atum.server.api.controller.PartitioningController
+import zio.test.Assertion.equalTo
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertZIO}
+import zio.{Scope, ZIO, ZLayer}
+
+object PatchPartitioningParentEndpointUnitTests extends ZIOSpecDefault with Endpoints with TestData {
+
+  private val partitioningControllerMock: PartitioningController = mock(classOf[PartitioningController])
+
+  when(partitioningControllerMock.patchPartitioningParent(1L, partitioningParentPatchDTO1))
+    .thenReturn(ZIO.succeed(SingleSuccessResponse(partitioningParentPatchDTO1, uuid1)))
+  when(partitioningControllerMock.patchPartitioningParent(1L, partitioningParentPatchDTO2))
+    .thenReturn(ZIO.fail(GeneralErrorResponse("error")))
+  when(partitioningControllerMock.patchPartitioningParent(1L, partitioningParentPatchDTO3))
+    .thenReturn(ZIO.fail(InternalServerErrorResponse("error")))
+  when(partitioningControllerMock.patchPartitioningParent(1L, partitioningParentPatchDTO4))
+    .thenReturn(ZIO.fail(ConflictErrorResponse("error")))
+  when(partitioningControllerMock.patchPartitioningParent(0L, partitioningParentPatchDTO4))
+    .thenReturn(ZIO.fail(NotFoundErrorResponse("Child Partitioning not found")))
+
+  private val partitioningControllerMockLayer = ZLayer.succeed(partitioningControllerMock)
+
+  private val patchPartitioningParentEndpointLogic = patchPartitioningParentEndpointV2
+    .zServerLogic({ case (partitioningId: Long, partitioningParentPatchDTO: PartitioningParentPatchDTO) =>
+      PartitioningController.patchPartitioningParent(partitioningId, partitioningParentPatchDTO)
+    })
+
+  override def spec: Spec[TestEnvironment with Scope, Any] = {
+    val backendStub = TapirStubInterpreter(SttpBackendStub.apply(new RIOMonadError[PartitioningController]))
+      .whenServerEndpoint(patchPartitioningParentEndpointLogic)
+      .thenRunLogic()
+      .backend()
+
+    val request = basicRequest
+      .patch(uri"https://test.com/api/v2/partitionings/1/ancestors")
+      .response(asJson[SingleSuccessResponse[PartitioningParentPatchDTO]])
+
+    suite("PatchPartitioningParentEndpointUnitTests")(
+      test("Returns expected PartitioningParentPatchDTO") {
+        val response = request
+          .body(partitioningParentPatchDTO1)
+          .send(backendStub)
+
+        val body = response.map(_.body)
+        val statusCode = response.map(_.code)
+
+        assertZIO(body <&> statusCode)(
+          equalTo(Right(SingleSuccessResponse(partitioningParentPatchDTO1, uuid1)), StatusCode.Ok)
+        )
+      },
+      test("Returns expected BadRequest") {
+        val response = request
+          .body(partitioningParentPatchDTO2)
+          .send(backendStub)
+
+        val statusCode = response.map(_.code)
+
+        assertZIO(statusCode)(equalTo(StatusCode.BadRequest))
+      },
+      test("Returns expected InternalServerError") {
+        val response = request
+          .body(partitioningParentPatchDTO3)
+          .send(backendStub)
+
+        val statusCode = response.map(_.code)
+
+        assertZIO(statusCode)(equalTo(StatusCode.InternalServerError))
+      },
+      test("Returns expected ConflictError") {
+        val response = request
+          .body(partitioningParentPatchDTO4)
+          .send(backendStub)
+
+        val statusCode = response.map(_.code)
+
+        assertZIO(statusCode)(equalTo(StatusCode.Conflict))
+      },
+      test("Returns expected NotFound") {
+        val response = request
+          .patch(uri"https://test.com/api/v2/partitionings/0/ancestors")
+          .body(partitioningParentPatchDTO4)
+          .send(backendStub)
+
+        val statusCode = response.map(_.code)
+
+        assertZIO(statusCode)(equalTo(StatusCode.NotFound))
+      }
+    )
+  }.provide(
+    partitioningControllerMockLayer
+  )
+}

--- a/server/src/test/scala/za/co/absa/atum/server/api/service/PartitioningServiceUnitTests.scala
+++ b/server/src/test/scala/za/co/absa/atum/server/api/service/PartitioningServiceUnitTests.scala
@@ -98,6 +98,14 @@ object PartitioningServiceUnitTests extends ZIOSpecDefault with TestData {
   when(partitioningRepositoryMock.getPartitioningMainFlow(3L))
     .thenReturn(ZIO.fail(GeneralDatabaseError("boom!")))
 
+  when(partitioningRepositoryMock.updatePartitioningParent(1L, partitioningParentPatchDTO1)).thenReturn(ZIO.unit)
+  when(partitioningRepositoryMock.updatePartitioningParent(1L, partitioningParentPatchDTO5))
+    .thenReturn(ZIO.fail(NotFoundDatabaseError("Parent Partitioning not found")))
+  when(partitioningRepositoryMock.updatePartitioningParent(0L, partitioningParentPatchDTO1))
+    .thenReturn(ZIO.fail(NotFoundDatabaseError("Child Partitioning not found")))
+  when(partitioningRepositoryMock.updatePartitioningParent(2L, partitioningParentPatchDTO1))
+    .thenReturn(ZIO.fail(GeneralDatabaseError("boom!")))
+
   private val partitioningRepositoryMockLayer = ZLayer.succeed(partitioningRepositoryMock)
 
   override def spec: Spec[TestEnvironment with Scope, Any] = {
@@ -281,6 +289,36 @@ object PartitioningServiceUnitTests extends ZIOSpecDefault with TestData {
         test("Returns expected NotFoundServiceError when flow doesn't exist") {
           assertZIO(PartitioningService.getFlowPartitionings(4L, Some(1), Some(1L)).exit)(
             failsWithA[NotFoundServiceError]
+          )
+        }
+      ),
+      suite("PatchPartitioningParentSuite")(
+        test("Returns expected Right with Unit") {
+          for {
+            result <- PartitioningService.patchPartitioningParent(1L, partitioningParentPatchDTO1)
+          } yield assertTrue(result == ())
+        },
+        test("Returns expected NotFoundServiceError") {
+          for {
+            result <- PartitioningService.patchPartitioningParent(1L, partitioningParentPatchDTO5).exit
+          } yield assertTrue(
+            result == Exit.fail(
+              NotFoundServiceError("Failed to perform 'updatePartitioningParent': Parent Partitioning not found")
+            )
+          )
+        },
+        test("Returns expected NotFoundServiceError") {
+          for {
+            result <- PartitioningService.patchPartitioningParent(0L, partitioningParentPatchDTO1).exit
+          } yield assertTrue(
+            result == Exit.fail(
+              NotFoundServiceError("Failed to perform 'updatePartitioningParent': Child Partitioning not found")
+            )
+          )
+        },
+        test("Returns expected GeneralServiceError") {
+          assertZIO(PartitioningService.patchPartitioningParent(2L, partitioningParentPatchDTO1).exit)(
+            failsWithA[GeneralServiceError]
           )
         }
       )


### PR DESCRIPTION
- Added the server portion of the PatchPartitioningParents.

Closes #273

Release notes:

Created endpoint /api/v2/partitionings/{partitioning_id}/ancestors to patch the partitioning parents.