### PR TITLE
monad error as implicit evidence instead of type bound in reader classes

### DIFF
--- a/reader/src/main/scala/za/co/absa/atum/reader/PartitioningReader.scala
+++ b/reader/src/main/scala/za/co/absa/atum/reader/PartitioningReader.scala
@@ -29,23 +29,25 @@ import za.co.absa.atum.reader.requests.QueryParamNames
 import za.co.absa.atum.reader.server.ServerConfig
 
 /**
- *
- * @param partitioning  - the Atum partitions to read the information from
- * @param serverConfig  - the Atum server configuration
- * @param backend       - sttp backend, that will be executing the requests
- * @tparam F            - the effect type (e.g. Future, IO, Task, etc.)
+ *  @param partitioning  - the Atum partitions to read the information from
+ *  @param serverConfig  - the Atum server configuration
+ *  @param backend       - sttp backend, that will be executing the requests
+ *  @tparam F            - the effect type (e.g. Future, IO, Task, etc.)
  */
-case class PartitioningReader[F[_]: MonadError](partitioning: AtumPartitions)
-                                   (implicit serverConfig: ServerConfig, backend: SttpBackend[F, Any])
-  extends Reader[F] with PartitioningIdProvider[F]{
+case class PartitioningReader[F[_]](partitioning: AtumPartitions)(implicit
+  serverConfig: ServerConfig,
+  backend: SttpBackend[F, Any],
+  me: MonadError[F]
+) extends Reader[F]
+    with PartitioningIdProvider[F] {
 
   /**
-   * Function to retrieve a page of checkpoints belonging to the partitioning.
-   * The checkpoints are ordered by their creation order.
+   *  Function to retrieve a page of checkpoints belonging to the partitioning.
+   *  The checkpoints are ordered by their creation order.
    *
-   * @param pageSize  - the size of the page (record count) to be returned
-   * @param offset    - offset of the page (starting position)
-   * @return          - a page of checkpoints
+   *  @param pageSize  - the size of the page (record count) to be returned
+   *  @param offset    - offset of the page (starting position)
+   *  @return          - a page of checkpoints
    */
   def getCheckpointsPage(pageSize: Int = 10, offset: Long = 0): F[RequestResult[PaginatedResponse[CheckpointV2DTO]]] = {
     for {
@@ -55,39 +57,48 @@ case class PartitioningReader[F[_]: MonadError](partitioning: AtumPartitions)
   }
 
   /**
-   * Function to retrieve a page of checkpoints of the given name belonging to the partitioning. (While the usual logic
-   * would suggest, there would be only one checkpoint of a name, nothing prevents to have checkpoints of the same name;
-   * also during reprocessing the checkpoints might multiply.)
-   * The checkpoints are ordered by their creation order.
+   *  Function to retrieve a page of checkpoints of the given name belonging to the partitioning. (While the usual logic
+   *  would suggest, there would be only one checkpoint of a name, nothing prevents to have checkpoints of the same name;
+   *  also during reprocessing the checkpoints might multiply.)
+   *  The checkpoints are ordered by their creation order.
    *
-   * @param checkpointName  - the name to filter with
-   * @param pageSize        - the size of the page (record count) to be returned
-   * @param offset          - offset of the page (starting position)
-   * @return                - a page of checkpoints
+   *  @param checkpointName  - the name to filter with
+   *  @param pageSize        - the size of the page (record count) to be returned
+   *  @param offset          - offset of the page (starting position)
+   *  @return                - a page of checkpoints
    */
-  def getCheckpointsOfNamePage(checkpointName: String, pageSize: Int = 10, offset: Long = 0): F[RequestResult[PaginatedResponse[CheckpointV2DTO]]] = {
+  def getCheckpointsOfNamePage(
+    checkpointName: String,
+    pageSize: Int = 10,
+    offset: Long = 0
+  ): F[RequestResult[PaginatedResponse[CheckpointV2DTO]]] = {
     for {
       partitioningIdOrError <- partitioningId(partitioning)
-      checkpointsOrError <- mapRequestResultF(partitioningIdOrError, queryCheckpoints(_, Some(checkpointName), pageSize, offset))
+      checkpointsOrError <- mapRequestResultF(
+        partitioningIdOrError,
+        queryCheckpoints(_, Some(checkpointName), pageSize, offset)
+      )
     } yield checkpointsOrError
   }
 
   /**
-   * Returns the additional data associated with the partitioning
+   *  Returns the additional data associated with the partitioning
    *
-   * @return - the additional data as they were save for the partitioning
+   *  @return - the additional data as they were save for the partitioning
    */
   def getAdditionalData: F[RequestResult[AdditionalDataDTO]] = {
-    for{
+    for {
       partitioningIdOrError <- partitioningId(partitioning)
       additionalDataOrError <- mapRequestResultF(partitioningIdOrError, queryAdditionalData)
     } yield additionalDataOrError.map(_.data)
   }
 
-  private def queryCheckpoints(partitioningId: Long,
-                               checkpointName: Option[String],
-                               limit: Int,
-                               offset: Long): F[RequestResult[PaginatedResponse[CheckpointV2DTO]]] = {
+  private def queryCheckpoints(
+    partitioningId: Long,
+    checkpointName: Option[String],
+    limit: Int,
+    offset: Long
+  ): F[RequestResult[PaginatedResponse[CheckpointV2DTO]]] = {
     val endpoint = s"/$Api/$V2/${V2Paths.Partitionings}/$partitioningId/${V2Paths.Checkpoints}"
     val params = Map(
       QueryParamNames.Limit -> limit.toString,

--- a/reader/src/test/scala/za/co/absa/atum/reader/FlowReaderUnitTests.scala
+++ b/reader/src/test/scala/za/co/absa/atum/reader/FlowReaderUnitTests.scala
@@ -37,7 +37,7 @@ import java.util.UUID
 
 class FlowReaderUnitTests extends AnyFunSuiteLike {
   private implicit val serverConfig: ServerConfig = ServerConfig.fromConfig()
-  private implicit val monad: MonadError[Identity] = IdMonad
+  private implicit val monadError: MonadError[Identity] = IdMonad
 
   test("mainFlowPartitioning is the same as partitioning") {
     val atumPartitions: AtumPartitions = AtumPartitions(List(
@@ -46,7 +46,7 @@ class FlowReaderUnitTests extends AnyFunSuiteLike {
     ))
     implicit val server: SttpBackend[Identity, Any] = SttpBackendStub.synchronous
 
-    val result = new FlowReader(atumPartitions).mainFlowPartitioning
+    val result = FlowReader(atumPartitions).mainFlowPartitioning
     assert(result == atumPartitions)
   }
 
@@ -193,6 +193,17 @@ class FlowReaderUnitTests extends AnyFunSuiteLike {
     val reader = FlowReader(atumPartitions)
     val result = reader.getCheckpointsOfNamePage("Test checkpoints 1")
     assert(result == Right(expectedData))
+  }
+
+  test("Instantiate FlowReader with implicit arguments passed explicitly") {
+    val atumPartitions: AtumPartitions = AtumPartitions(List(
+      "a" -> "b",
+      "c" -> "d"
+    ))
+    implicit val server: SttpBackend[Identity, Any] = SttpBackendStub.synchronous
+
+    val flowReader = FlowReader(atumPartitions)(serverConfig, server, monadError)
+    assert(flowReader.isInstanceOf[FlowReader[Identity]])
   }
 
 }


### PR DESCRIPTION
MonadError instance passed as implicit evidence instead of type bound.
Closes #339 

Release notes:
- Reader classes' signatures changed to receive MonadError instance as implicit evidence instead of type bound