### PR TITLE
Fix Build Badge in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Atum Service
 
-[![Build](https://github.com/AbsaOSS/spark-commons/actions/workflows/build.yml/badge.svg)](https://github.com/AbsaOSS/spark-commons/actions/workflows/build.yml)
+[![Build](https://github.com/AbsaOSS/atum-service/blob/master/.github/workflows/build.yml/badge.)](https://github.com/AbsaOSS/atum-service/blob/master/.github/workflows/build.yml)
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/Naereen/StrapDown.js/graphs/commit-activity)
 


### PR DESCRIPTION
Fix Build Badge in `README.md`

Closes #373

Release Notes:
- Updated build tag to include: `https://github.com/AbsaOSS/atum-service/blob/master/.github/workflows/build.yml`