### PR TITLE
Added factory for config-backed Atum-Agent

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -35,6 +35,7 @@ Create a dedicated agent instance from a custom Typesafe config.
 ```scala
 import com.typesafe.config.ConfigFactory
 import za.co.absa.atum.agent.AtumAgent
+import za.co.absa.atum.model.types.basic.AtumPartitions
 
 val config = ConfigFactory.parseString(
   """
@@ -44,6 +45,8 @@ val config = ConfigFactory.parseString(
 )
 
 val customAgent = AtumAgent.fromConfig(config)
+val atumPartitions = AtumPartitions("country" -> "za", "dataset" -> "customers")
+val atumContext = customAgent.getOrCreateAtumContext(atumPartitions)
 ```
 
 #### AtumPartitions

--- a/agent/README.md
+++ b/agent/README.md
@@ -20,8 +20,13 @@ val atumContextWithSalaryAbsMeasure = atumContextInstanceWithRecordCount
 
 ### Option 2
 Use `AtumPartitions` to get an `AtumContext` from the service using the `AtumAgent`.
+
 ```scala
-    val atumContext1 = AtumAgent.getOrCreateAtumContext(atumPartitions)
+import za.co.absa.atum.agent.AtumAgent
+import za.co.absa.atum.model.types.basic.AtumPartitions
+
+val atumPartitions = AtumPartitions("country" -> "za", "dataset" -> "customers")
+val atumContext1 = AtumAgent.getOrCreateAtumContext(atumPartitions)
 ```
 
 ### Option 3
@@ -31,7 +36,13 @@ Create a dedicated agent instance from a custom Typesafe config.
 import com.typesafe.config.ConfigFactory
 import za.co.absa.atum.agent.AtumAgent
 
-val config = ConfigFactory.load()
+val config = ConfigFactory.parseString(
+  """
+    |atum.dispatcher.type = "http"
+    |atum.dispatcher.http.url = "http://localhost:8080"
+    |""".stripMargin
+)
+
 val customAgent = AtumAgent.fromConfig(config)
 ```
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -24,6 +24,17 @@ Use `AtumPartitions` to get an `AtumContext` from the service using the `AtumAge
     val atumContext1 = AtumAgent.createAtumContext(atumPartition)
 ```
 
+### Option 3
+Create a dedicated agent instance from a custom Typesafe config.
+
+```scala
+import com.typesafe.config.ConfigFactory
+import za.co.absa.atum.agent.AtumAgent
+
+val config = ConfigFactory.load()
+val customAgent = AtumAgent.fromConfig(config)
+```
+
 #### AtumPartitions
 A list of key values that maintains the order of arrival of the items, the `AtumService`
 is able to deliver the correct `AtumContext` according to the `AtumPartitions` we give it.

--- a/agent/README.md
+++ b/agent/README.md
@@ -21,7 +21,7 @@ val atumContextWithSalaryAbsMeasure = atumContextInstanceWithRecordCount
 ### Option 2
 Use `AtumPartitions` to get an `AtumContext` from the service using the `AtumAgent`.
 ```scala
-    val atumContext1 = AtumAgent.createAtumContext(atumPartition)
+    val atumContext1 = AtumAgent.getOrCreateAtumContext(atumPartitions)
 ```
 
 ### Option 3

--- a/agent/src/main/scala/za/co/absa/atum/agent/AtumAgent.scala
+++ b/agent/src/main/scala/za/co/absa/atum/agent/AtumAgent.scala
@@ -131,4 +131,7 @@ object AtumAgent extends AtumAgent {
     }
   }
 
+  def fromConfig(config: Config): AtumAgent = new AtumAgent {
+    override val dispatcher: Dispatcher = dispatcherFromConfig(config)
+  }
 }

--- a/agent/src/main/scala/za/co/absa/atum/agent/AtumAgent.scala
+++ b/agent/src/main/scala/za/co/absa/atum/agent/AtumAgent.scala
@@ -66,7 +66,7 @@ trait AtumAgent {
    *  Provides an AtumContext given a `AtumPartitions` instance. Retrieves the data from AtumService API.
    *
    *  Note: if partitioning doesn't exist in the store yet, a new one will be created with the author stored in
-   *    `AtumAgent.currentUser`. If partitioning already exists, this attribute will be ignored because there
+   *    `currentUser`. If partitioning already exists, this attribute will be ignored because there
    *    already is an author who previously created the partitioning in the data store. Each Atum Context thus
    *    can have different author potentially.
    *
@@ -75,7 +75,7 @@ trait AtumAgent {
    *          partitioning already existed.
    */
   def getOrCreateAtumContext(atumPartitions: AtumPartitions): AtumContext = {
-    val authorIfNew = AtumAgent.currentUser
+    val authorIfNew = this.currentUser
     val partitioningDTO = PartitioningSubmitDTO(atumPartitions.toPartitioningDTO, None, authorIfNew)
 
     val atumContextDTO = dispatcher.createPartitioning(partitioningDTO)
@@ -92,7 +92,7 @@ trait AtumAgent {
    *  @return Atum context object
    */
   def getOrCreateAtumSubContext(subPartitions: AtumPartitions)(implicit parentAtumContext: AtumContext): AtumContext = {
-    val authorIfNew = AtumAgent.currentUser
+    val authorIfNew = this.currentUser
     val newPartitions: AtumPartitions = parentAtumContext.atumPartitions ++ subPartitions
 
     val newPartitionsDTO = newPartitions.toPartitioningDTO
@@ -120,9 +120,9 @@ trait AtumAgent {
 
 object AtumAgent extends AtumAgent {
 
-  override lazy val dispatcher: Dispatcher = dispatcherFromConfig()
+  override val dispatcher: Dispatcher = dispatcherFromConfig()
 
-  def dispatcherFromConfig(config: Config = ConfigFactory.load()): Dispatcher = {
+  private[agent] def dispatcherFromConfig(config: Config = ConfigFactory.load()): Dispatcher = {
     config.getString("atum.dispatcher.type") match {
       case "http" => new HttpDispatcher(config)
       case "console" => new ConsoleDispatcher(config)
@@ -132,6 +132,6 @@ object AtumAgent extends AtumAgent {
   }
 
   def fromConfig(config: Config): AtumAgent = new AtumAgent {
-    override lazy val dispatcher: Dispatcher = dispatcherFromConfig(config)
+    override val dispatcher: Dispatcher = dispatcherFromConfig(config)
   }
 }

--- a/agent/src/main/scala/za/co/absa/atum/agent/AtumAgent.scala
+++ b/agent/src/main/scala/za/co/absa/atum/agent/AtumAgent.scala
@@ -120,7 +120,7 @@ trait AtumAgent {
 
 object AtumAgent extends AtumAgent {
 
-  override val dispatcher: Dispatcher = dispatcherFromConfig()
+  override lazy val dispatcher: Dispatcher = dispatcherFromConfig()
 
   def dispatcherFromConfig(config: Config = ConfigFactory.load()): Dispatcher = {
     config.getString("atum.dispatcher.type") match {
@@ -132,6 +132,6 @@ object AtumAgent extends AtumAgent {
   }
 
   def fromConfig(config: Config): AtumAgent = new AtumAgent {
-    override val dispatcher: Dispatcher = dispatcherFromConfig(config)
+    override lazy val dispatcher: Dispatcher = dispatcherFromConfig(config)
   }
 }

--- a/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
@@ -44,11 +44,6 @@ class AtumAgentUnitTests extends AnyFunSuiteLike {
   }
 
   test("AtumAgent creates dispatcher per configuration") {
-    def configForDispatcher(dispatcherType: String): Config = {
-      val emptyConfig = ConfigFactory.empty()
-      val value = ConfigValueFactory.fromAnyRef(dispatcherType)
-      emptyConfig.withValue("atum.dispatcher.type", value)
-    }
 
     AtumAgent.dispatcherFromConfig(configOf(Map(
       "atum.dispatcher.type" -> "http",

--- a/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
@@ -19,6 +19,7 @@ package za.co.absa.atum.agent
 import com.typesafe.config.{Config, ConfigException, ConfigFactory, ConfigValueFactory}
 import org.scalatest.funsuite.AnyFunSuiteLike
 import za.co.absa.atum.agent.dispatcher.{CapturingDispatcher, ConsoleDispatcher, HttpDispatcher}
+import za.co.absa.atum.model.dto.PartitioningSubmitDTO
 import za.co.absa.atum.model.types.basic.AtumPartitions
 
 class AtumAgentUnitTests extends AnyFunSuiteLike {
@@ -92,7 +93,43 @@ class AtumAgentUnitTests extends AnyFunSuiteLike {
     }
   }
 
-  // Small helper
+  test("config-backed agents are independent and use their own currentUser resolution") {
+    val partitioning1 = AtumPartitions("domain" -> "one")
+    val partitioning2 = AtumPartitions("domain" -> "two")
+
+    final class RecordingAgent(userName: String) extends AtumAgent {
+      private var recordedAuthorsInternal: Vector[String] = Vector.empty
+
+      override val dispatcher: CapturingDispatcher =
+        AtumAgent.dispatcherFromConfig(configOf(Map(
+          "atum.dispatcher.type" -> "capture",
+          "atum.dispatcher.capture.capture-limit" -> 10
+        ))).asInstanceOf[CapturingDispatcher]
+
+      override private[agent] def currentUser: String = userName
+
+      override def getOrCreateAtumContext(atumPartitions: AtumPartitions): AtumContext = {
+        recordedAuthorsInternal = recordedAuthorsInternal :+ this.currentUser
+        super.getOrCreateAtumContext(atumPartitions)
+      }
+
+      def recordedAuthors: Seq[String] = recordedAuthorsInternal
+    }
+
+    val agentA = new RecordingAgent("alice")
+    val agentB = new RecordingAgent("bob")
+
+    val contextA = agentA.getOrCreateAtumContext(partitioning1)
+    val contextB = agentB.getOrCreateAtumContext(partitioning2)
+
+    assert(contextA.agent == agentA)
+    assert(contextB.agent == agentB)
+    assert(agentA.recordedAuthors == Seq("alice"))
+    assert(agentB.recordedAuthors == Seq("bob"))
+    assert(agentA.getOrCreateAtumContext(partitioning1) == contextA)
+    assert(agentB.getOrCreateAtumContext(partitioning2) == contextB)
+  }
+
   private def configOf(configValues: Map[String, Any]): Config = {
     val emptyConfig = ConfigFactory.empty()
     configValues.foldLeft(emptyConfig) { case (acc, (configKey, value)) =>

--- a/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
@@ -134,6 +134,35 @@ class AtumAgentUnitTests extends AnyFunSuiteLike {
     assert(agentB.recordedAuthors == Seq("bob", "bob"))
   }
 
+  test("AtumAgent.fromConfig creates independent agent instances with separate context stores") {
+    val sharedPartitioning = AtumPartitions("domain" -> "one")
+
+    val configA = configOf(Map(
+      "atum.dispatcher.type" -> "capture",
+      "atum.dispatcher.capture.capture-limit" -> 10
+    ))
+    val configB = configOf(Map(
+      "atum.dispatcher.type" -> "capture",
+      "atum.dispatcher.capture.capture-limit" -> 10
+    ))
+
+    val agentA = AtumAgent.fromConfig(configA)
+    val agentB = AtumAgent.fromConfig(configB)
+
+    val contextA1 = agentA.getOrCreateAtumContext(sharedPartitioning)
+    val contextA2 = agentA.getOrCreateAtumContext(sharedPartitioning)
+    val contextB1 = agentB.getOrCreateAtumContext(sharedPartitioning)
+    val contextB2 = agentB.getOrCreateAtumContext(sharedPartitioning)
+
+    assert(contextA1 eq contextA2)
+    assert(contextB1 eq contextB2)
+    assert(contextA1 ne contextB1)
+
+    assert(contextA1.agent == agentA)
+    assert(contextB1.agent == agentB)
+    assert(agentA.dispatcher ne agentB.dispatcher)
+  }
+
   private def configOf(configValues: Map[String, Any]): Config = {
     val emptyConfig = ConfigFactory.empty()
     configValues.foldLeft(emptyConfig) { case (acc, (configKey, value)) =>

--- a/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
@@ -93,4 +93,16 @@ class AtumAgentUnitTests extends AnyFunSuiteLike {
 
   }
 
+  test("AtumAgent can create a config-backed agent instance") {
+    val config = ConfigFactory.empty()
+      .withValue("atum.dispatcher.type", ConfigValueFactory.fromAnyRef("http"))
+      .withValue("atum.dispatcher.http.url", ConfigValueFactory.fromAnyRef("http://localhost:8080"))
+
+    val agent = AtumAgent.fromConfig(config)
+
+    agent.dispatcher match {
+      case _: HttpDispatcher  => succeed
+      case _                  => fail("Expected HttpDispatcher")
+    }
+  }
 }

--- a/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
@@ -94,8 +94,7 @@ class AtumAgentUnitTests extends AnyFunSuiteLike {
   }
 
   test("config-backed agents are independent and use their own currentUser resolution") {
-    val partitioning1 = AtumPartitions("domain" -> "one")
-    val partitioning2 = AtumPartitions("domain" -> "two")
+    val sharedPartitioning = AtumPartitions("domain" -> "one")
 
     final class RecordingAgent(userName: String) extends AtumAgent {
       private var recordedAuthorsInternal: Vector[String] = Vector.empty
@@ -119,15 +118,20 @@ class AtumAgentUnitTests extends AnyFunSuiteLike {
     val agentA = new RecordingAgent("alice")
     val agentB = new RecordingAgent("bob")
 
-    val contextA = agentA.getOrCreateAtumContext(partitioning1)
-    val contextB = agentB.getOrCreateAtumContext(partitioning2)
+    val contextA1 = agentA.getOrCreateAtumContext(sharedPartitioning)
+    val contextA2 = agentA.getOrCreateAtumContext(sharedPartitioning)
+    val contextB1 = agentB.getOrCreateAtumContext(sharedPartitioning)
+    val contextB2 = agentB.getOrCreateAtumContext(sharedPartitioning)
 
-    assert(contextA.agent == agentA)
-    assert(contextB.agent == agentB)
-    assert(agentA.recordedAuthors == Seq("alice"))
-    assert(agentB.recordedAuthors == Seq("bob"))
-    assert(agentA.getOrCreateAtumContext(partitioning1) == contextA)
-    assert(agentB.getOrCreateAtumContext(partitioning2) == contextB)
+    assert(contextA1 eq contextA2)
+    assert(contextB1 eq contextB2)
+    assert(contextA1 ne contextB1)
+
+    assert(contextA1.agent == agentA)
+    assert(contextB1.agent == agentB)
+
+    assert(agentA.recordedAuthors == Seq("alice", "alice"))
+    assert(agentB.recordedAuthors == Seq("bob", "bob"))
   }
 
   private def configOf(configValues: Map[String, Any]): Config = {

--- a/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
@@ -50,14 +50,6 @@ class AtumAgentUnitTests extends AnyFunSuiteLike {
       emptyConfig.withValue("atum.dispatcher.type", value)
     }
 
-    def configOf(configValues: Map[String, Any]): Config = {
-      val emptyConfig = ConfigFactory.empty()
-      configValues.foldLeft(emptyConfig) { case (acc, (configKey, value)) =>
-        val configValue = ConfigValueFactory.fromAnyRef(value)
-        acc.withValue(configKey, configValue)
-      }
-    }
-
     AtumAgent.dispatcherFromConfig(configOf(Map(
       "atum.dispatcher.type" -> "http",
       "atum.dispatcher.http.url" -> "http://localhost:8080"
@@ -94,15 +86,24 @@ class AtumAgentUnitTests extends AnyFunSuiteLike {
   }
 
   test("AtumAgent can create a config-backed agent instance") {
-    val config = ConfigFactory.empty()
-      .withValue("atum.dispatcher.type", ConfigValueFactory.fromAnyRef("http"))
-      .withValue("atum.dispatcher.http.url", ConfigValueFactory.fromAnyRef("http://localhost:8080"))
-
-    val agent = AtumAgent.fromConfig(config)
+    val agent = AtumAgent.fromConfig(configOf(Map(
+      "atum.dispatcher.type" -> "http",
+      "atum.dispatcher.http.url" -> "http://localhost:8080"
+    )))
 
     agent.dispatcher match {
       case _: HttpDispatcher  => succeed
       case _                  => fail("Expected HttpDispatcher")
     }
   }
+
+  //Small Helper
+  def configOf(configValues: Map[String, Any]): Config = {
+    val emptyConfig = ConfigFactory.empty()
+    configValues.foldLeft(emptyConfig) { case (acc, (configKey, value)) =>
+      val configValue = ConfigValueFactory.fromAnyRef(value)
+      acc.withValue(configKey, configValue)
+    }
+  }
+
 }

--- a/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/AtumAgentUnitTests.scala
@@ -97,8 +97,8 @@ class AtumAgentUnitTests extends AnyFunSuiteLike {
     }
   }
 
-  //Small Helper
-  def configOf(configValues: Map[String, Any]): Config = {
+  // Small helper
+  private def configOf(configValues: Map[String, Any]): Config = {
     val emptyConfig = ConfigFactory.empty()
     configValues.foldLeft(emptyConfig) { case (acc, (configKey, value)) =>
       val configValue = ConfigValueFactory.fromAnyRef(value)


### PR DESCRIPTION
## Task:
Adds a factory method to create an `AtumAgent` instance backed by an explicitly provided `Typesafe Config`, enabling multiple agents with different dispatcher setups within the same JVM.

## Context:
- https://github.com/absa-group/ursa-unify-deployment/pull/400
- https://github.com/absa-group/AUL/pull/4930

The above PRs updates the deployment pipeline to extract, package, and publish the external TypeSafe config for the data-measurement Spark plugin and ensure it is shipped to Spark via `--files`:

This supports the “external first, classpath fallback” strategy within AUL: the plugin first attempts to load `application.conf` distributed through Spark `--files`, and falls back to the classpath config if no external file is available.

Essentially, we want to externalize all configuration files. So, it is easier for the Ops teams and Dev teams to make changes to the configuration files without a need to always release a new version of Atum-Services or Unify. But since Atum-Services is in the codebase of Unify, a small change is needed on Atum-Services to be able to externalize these config files.

## Closes: 
#438 

## Release Notes:
- Added factory for config-backed agent
  -  Added function `fromConfig` to `AtumAgent`
  -  Added Unit Tests
  -  Updated `README` to include Option 3