### PR TITLE
#205: adding retry mechanism for Atum agent on HTTP dispatcher level

### DIFF
--- a/agent/src/main/resources/reference.conf
+++ b/agent/src/main/resources/reference.conf
@@ -20,3 +20,12 @@ atum.dispatcher.type="http"
 # Maximum number of dispatch captures to keep in memory
 #atum.dispatcher.capture.capture-limit=1000 # 0 means no limit
 
+# Retry configuration for the HTTP dispatcher (all keys optional — defaults apply if absent)
+#atum.dispatcher.http.retry.max-retries=3          # number of retries after first failure (0 = no retries)
+#atum.dispatcher.http.retry.initial-delay-ms=1000  # initial backoff delay in milliseconds
+#atum.dispatcher.http.retry.max-delay-ms=10000     # maximum backoff delay cap in milliseconds
+
+# HTTP timeout configuration (all keys optional — defaults apply if absent)
+#atum.dispatcher.http.timeout.connect-ms=10000     # TCP connection timeout in milliseconds (default: 10 000)
+#atum.dispatcher.http.timeout.read-ms=30000        # response read timeout in milliseconds (default: 30 000)
+#atum.dispatcher.http.timeout.write-ms=10000       # request write timeout in milliseconds (default: 10 000)

--- a/agent/src/main/scala/za/co/absa/atum/agent/dispatcher/HttpDispatcher.scala
+++ b/agent/src/main/scala/za/co/absa/atum/agent/dispatcher/HttpDispatcher.scala
@@ -153,7 +153,11 @@ class HttpDispatcher(config: Config) extends Dispatcher(config) with Logging {
       .body(checkpointV2DTO.asJsonString)
 
     val response = withRetry(request)
-    handleResponseBody(response)
+    // 409 Conflict means the checkpoint was already saved (e.g. prior attempt succeeded but response was lost).
+    // This is expected on retry and should not be treated as an error.
+    if (response.code != StatusCode.Conflict) {
+      handleResponseBody(response)
+    }
   }
 
   override protected[agent] def updateAdditionalData(

--- a/agent/src/main/scala/za/co/absa/atum/agent/dispatcher/HttpDispatcher.scala
+++ b/agent/src/main/scala/za/co/absa/atum/agent/dispatcher/HttpDispatcher.scala
@@ -17,6 +17,7 @@
 package za.co.absa.atum.agent.dispatcher
 
 import com.typesafe.config.Config
+import okhttp3.OkHttpClient
 import org.apache.spark.internal.Logging
 import sttp.capabilities
 import sttp.client3._
@@ -28,6 +29,8 @@ import za.co.absa.atum.model.ApiPaths
 import za.co.absa.atum.model.dto._
 import za.co.absa.atum.model.envelopes.SuccessResponse.{MultiSuccessResponse, SingleSuccessResponse}
 import za.co.absa.atum.model.utils.JsonSyntaxExtensions._
+
+import java.util.concurrent.TimeUnit
 
 class HttpDispatcher(config: Config) extends Dispatcher(config) with Logging {
   import HttpDispatcher._
@@ -42,7 +45,21 @@ class HttpDispatcher(config: Config) extends Dispatcher(config) with Logging {
     .header("Content-Type", "application/json")
     .response(asString)
 
-  private[dispatcher] val backend: SttpBackend[Identity, capabilities.WebSockets] = OkHttpSyncBackend()
+  private[dispatcher] val backend: SttpBackend[Identity, capabilities.WebSockets] = {
+    val connectTimeoutMs = optionalLong(ConnectTimeoutKey).getOrElse(DefaultConnectTimeoutMs)
+    val readTimeoutMs = optionalLong(ReadTimeoutKey).getOrElse(DefaultReadTimeoutMs)
+    val writeTimeoutMs = optionalLong(WriteTimeoutKey).getOrElse(DefaultWriteTimeoutMs)
+
+    val okHttpClient = new OkHttpClient.Builder()
+      .connectTimeout(connectTimeoutMs, TimeUnit.MILLISECONDS)
+      .readTimeout(readTimeoutMs, TimeUnit.MILLISECONDS)
+      .writeTimeout(writeTimeoutMs, TimeUnit.MILLISECONDS)
+      .build()
+
+    OkHttpSyncBackend.usingClient(okHttpClient)
+  }
+
+  private val httpRetry: HttpRetry = HttpRetry.fromConfig(config)
 
   /**
    *  This method is used to get the partitioning ID from the server.
@@ -53,7 +70,7 @@ class HttpDispatcher(config: Config) extends Dispatcher(config) with Logging {
     val encodedPartitioning = partitioning.asBase64EncodedJsonString
     val request = commonAtumRequest.get(getPartitioningIdEndpoint.addParam("partitioning", encodedPartitioning))
 
-    val response = backend.send(request)
+    val response = withRetry(request)
 
     handleResponseBody(response).as[SingleSuccessResponse[PartitioningWithIdDTO]].data.id
   }
@@ -62,7 +79,7 @@ class HttpDispatcher(config: Config) extends Dispatcher(config) with Logging {
     val encodedPartitioning = partitioning.asBase64EncodedJsonString
     val request = commonAtumRequest.get(getPartitioningIdEndpoint.addParam("partitioning", encodedPartitioning))
 
-    val response = backend.send(request)
+    val response = withRetry(request)
 
     response.code match {
       case StatusCode.NotFound => None
@@ -85,7 +102,7 @@ class HttpDispatcher(config: Config) extends Dispatcher(config) with Logging {
             partitioning.authorIfNew
           ).asJsonString
         )
-      val response = backend.send(request)
+      val response = withRetry(request)
       handleResponseBody(response).as[SingleSuccessResponse[PartitioningWithIdDTO]].data
     }
 
@@ -94,7 +111,7 @@ class HttpDispatcher(config: Config) extends Dispatcher(config) with Logging {
         s"$serverUrl$apiV2/${ApiPaths.V2Paths.Partitionings}/${newPartitioningWithIdDTO.id}/${ApiPaths.V2Paths.Measures}"
       )
       val req = commonAtumRequest.get(endpoint)
-      val resp = backend.send(req)
+      val resp = withRetry(req)
       handleResponseBody(resp).as[MultiSuccessResponse[MeasureDTO]].data.toSet
     }
 
@@ -103,7 +120,7 @@ class HttpDispatcher(config: Config) extends Dispatcher(config) with Logging {
         s"$serverUrl$apiV2/${ApiPaths.V2Paths.Partitionings}/${newPartitioningWithIdDTO.id}/${ApiPaths.V2Paths.AdditionalData}"
       )
       val req = commonAtumRequest.get(endpoint)
-      val resp = backend.send(req)
+      val resp = withRetry(req)
       handleResponseBody(resp).as[MultiSuccessResponse[AdditionalDataItemV2DTO]]
     }
 
@@ -135,7 +152,7 @@ class HttpDispatcher(config: Config) extends Dispatcher(config) with Logging {
       .post(endpoint)
       .body(checkpointV2DTO.asJsonString)
 
-    val response = backend.send(request)
+    val response = withRetry(request)
     handleResponseBody(response)
   }
 
@@ -154,16 +171,34 @@ class HttpDispatcher(config: Config) extends Dispatcher(config) with Logging {
       .patch(endpoint)
       .body(additionalDataPatchDTO.asJsonString)
 
-    val response = backend.send(request)
+    val response = withRetry(request)
 
-    val data: AdditionalDataDTO.Data = handleResponseBody(response).as[MultiSuccessResponse[AdditionalDataItemV2DTO]]
+    val data: AdditionalDataDTO.Data = handleResponseBody(response)
+      .as[MultiSuccessResponse[AdditionalDataItemV2DTO]]
       .data
-      .map( item => item.value match {
-        case Some(_) => item.key -> Some(AdditionalDataItemDTO(item.value.get, item.author))
-        case None => item.key -> None
-      }).toMap
+      .map(item =>
+        item.value match {
+          case Some(_) => item.key -> Some(AdditionalDataItemDTO(item.value.get, item.author))
+          case None => item.key -> None
+        }
+      )
+      .toMap
 
     AdditionalDataDTO(data)
+  }
+
+  /**
+   * Sends `request` via the sttp backend, retrying on transient failures with exponential backoff.
+   * Retries on HTTP 5xx (server errors) and IOException (covers network failures,
+   * connection resets, and SocketTimeoutException which OkHttp throws on read/connect timeout).
+   */
+  private def withRetry(
+    request: Request[Either[String, String], capabilities.WebSockets]
+  ): Response[Either[String, String]] = {
+    httpRetry.retry(backend.send(request))(_.code.code >= StatusCode.InternalServerError.code) {
+      (attempt, total, delay, reason) =>
+        log.warn(s"Atum agent: $reason on attempt $attempt/$total, retrying in ${delay}ms")
+    }
   }
 
   private def handleResponseBody(response: Response[Either[String, String]]): String = {
@@ -173,8 +208,19 @@ class HttpDispatcher(config: Config) extends Dispatcher(config) with Logging {
     }
   }
 
+  private def optionalLong(key: String): Option[Long] =
+    if (config.hasPath(key)) Some(config.getLong(key)) else None
+
 }
 
 object HttpDispatcher {
   private val UrlKey = "atum.dispatcher.http.url"
+  private val ConnectTimeoutKey = "atum.dispatcher.http.timeout.connect-ms"
+  private val ReadTimeoutKey = "atum.dispatcher.http.timeout.read-ms"
+  private val WriteTimeoutKey = "atum.dispatcher.http.timeout.write-ms"
+
+  // OkHttp defaults are 10s each; 30s read gives more headroom for slow DB queries under burst load
+  private val DefaultConnectTimeoutMs = 10000L
+  private val DefaultReadTimeoutMs = 30000L
+  private val DefaultWriteTimeoutMs = 10000L
 }

--- a/agent/src/main/scala/za/co/absa/atum/agent/dispatcher/HttpRetry.scala
+++ b/agent/src/main/scala/za/co/absa/atum/agent/dispatcher/HttpRetry.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.atum.agent.dispatcher
+
+import com.typesafe.config.Config
+
+/**
+ *  Retry configuration and execution for [[HttpDispatcher]].
+ *
+ *  All three parameters are optional in the config: if the `atum.dispatcher.http.retry` block is absent
+ *  the [[HttpRetry.Default]] values are used and no `ConfigException` is thrown.
+ *
+ *  @param maxRetries   Maximum number of retry attempts after the first failure (0 = no retries).
+ *  @param initialDelay Initial backoff delay in milliseconds; doubles on every subsequent attempt.
+ *  @param maxDelay     Upper cap for the computed backoff delay in milliseconds.
+ */
+case class HttpRetry(
+  maxRetries: Int,
+  initialDelay: Long,
+  maxDelay: Long
+) {
+
+  private val random = new scala.util.Random()
+
+  // Maximum exponent to prevent Long overflow when computing initialDelay * 2^attempt
+  private val MaxExponent = 30
+  // Fraction of the delay added as random jitter (0.1 = up to 10% extra).
+  // When many agents fail simultaneously, jitter spreads their retries over a short window instead of all hitting the
+  // server at the same instant.
+  private val JitterFraction = 0.1
+
+  /**
+   * Computes the backoff delay for a given attempt using exponential backoff with jitter.
+   *
+   * @param attempt Zero-based attempt index (0 = first retry delay, 1 = second, ...).
+   * @return Delay in milliseconds to sleep before the next attempt.
+   */
+  private[dispatcher] def computeDelay(attempt: Int): Long = {
+    val exponential = initialDelay * math.pow(2, math.min(attempt, MaxExponent)).toLong
+    val cappedDelay = math.min(exponential, maxDelay)
+    cappedDelay + (random.nextDouble() * cappedDelay * JitterFraction).toLong
+  }
+
+  /**
+   *  Executes `action`, retrying on transient failures with exponential backoff.
+   *
+   *  Retry conditions:
+   *   - `isRetryable(result)` returns true (e.g. HTTP 5xx)
+   *   - `java.io.IOException` is thrown (network-level failure)
+   *
+   *  No-retry conditions (fail immediately):
+   *   - `isRetryable(result)` returns false (e.g. 2xx, 4xx)
+   *   - Any non-IOException exception
+   *
+   *  @param action      The by-name action to execute (called on each attempt).
+   *  @param isRetryable Predicate on the result — true means the attempt should be retried.
+   *  @param onRetry     Callback invoked before each retry sleep, receiving
+   *                    (attemptNumber 1-based, totalAttempts, delayMs, reason).
+   *  @return The result of the first non-retryable attempt, or the last result after retries exhausted.
+   *  @throws java.io.IOException if all attempts result in an IOException.
+   */
+  private[dispatcher] def retry[T](
+    action: => T
+  )(isRetryable: T => Boolean)(onRetry: (Int, Int, Long, String) => Unit): T = {
+    val totalAttempts = maxRetries + 1
+    var attempt = 0
+
+    while (true) {
+      try {
+        val result = action
+        if (isRetryable(result) && attempt < maxRetries) {
+          val delay = computeDelay(attempt)
+          onRetry(attempt + 1, totalAttempts, delay, "retryable response")
+          Thread.sleep(delay)
+          attempt += 1
+        } else {
+          return result
+        }
+      } catch {
+        case e: java.io.IOException =>
+          if (attempt < maxRetries) {
+            val delay = computeDelay(attempt)
+            onRetry(attempt + 1, totalAttempts, delay, s"IOException: ${e.getMessage}")
+            Thread.sleep(delay)
+            attempt += 1
+          } else {
+            throw e
+          }
+      }
+    }
+
+    // Unreachable: while(true) always returns or throws, but the compiler cannot infer that.
+    throw new IllegalStateException("retry loop exited without a result")
+  }
+}
+
+object HttpRetry {
+
+  private val MaxRetriesKey = "atum.dispatcher.http.retry.max-retries"
+  private val InitialDelayKey = "atum.dispatcher.http.retry.initial-delay-ms"
+  private val MaxDelayKey = "atum.dispatcher.http.retry.max-delay-ms"
+
+  /** Sensible out-of-the-box defaults: 3 retries, 1 s initial delay, 10 s cap. */
+  val Default: HttpRetry = HttpRetry(
+    maxRetries = 3,
+    initialDelay = 1000L,
+    maxDelay = 10000L
+  )
+
+  /**
+   *  Reads retry configuration from a Typesafe [[Config]] instance.
+   *
+   *  Each key is optional: if absent, the corresponding [[Default]] value is used.
+   *  This design ensures backward-compatibility — existing configs that omit the
+   *  `atum.dispatcher.http.retry` block will never throw a `ConfigException`.
+   *
+   *  @param config Typesafe Config, typically the application config passed to [[HttpDispatcher]].
+   *  @return Populated [[HttpRetry]], falling back to [[Default]] for any absent key.
+   */
+  def fromConfig(config: Config): HttpRetry = {
+    val maxRetries = if (config.hasPath(MaxRetriesKey)) config.getInt(MaxRetriesKey) else Default.maxRetries
+    val initialDelay = if (config.hasPath(InitialDelayKey)) config.getLong(InitialDelayKey) else Default.initialDelay
+    val maxDelay = if (config.hasPath(MaxDelayKey)) config.getLong(MaxDelayKey) else Default.maxDelay
+
+    require(maxRetries >= 0, s"atum.dispatcher.http.retry.max-retries must be >= 0, got $maxRetries")
+    require(initialDelay > 0, s"atum.dispatcher.http.retry.initial-delay-ms must be > 0, got $initialDelay")
+    require(maxDelay > 0, s"atum.dispatcher.http.retry.max-delay-ms must be > 0, got $maxDelay")
+
+    HttpRetry(maxRetries, initialDelay, maxDelay)
+  }
+}

--- a/agent/src/main/scala/za/co/absa/atum/agent/dispatcher/HttpRetry.scala
+++ b/agent/src/main/scala/za/co/absa/atum/agent/dispatcher/HttpRetry.scala
@@ -44,10 +44,10 @@ case class HttpRetry(
   private val JitterFraction = 0.1
 
   /**
-   * Computes the backoff delay for a given attempt using exponential backoff with jitter.
+   *  Computes the backoff delay for a given attempt using exponential backoff with jitter.
    *
-   * @param attempt Zero-based attempt index (0 = first retry delay, 1 = second, ...).
-   * @return Delay in milliseconds to sleep before the next attempt.
+   *  @param attempt Zero-based attempt index (0 = first retry delay, 1 = second, ...).
+   *  @return Delay in milliseconds to sleep before the next attempt.
    */
   private[dispatcher] def computeDelay(attempt: Int): Long = {
     val exponential = initialDelay * math.pow(2, math.min(attempt, MaxExponent)).toLong
@@ -122,7 +122,7 @@ object HttpRetry {
   )
 
   /**
-   *  Reads retry configuration from a Typesafe [[Config]] instance.
+   *  Reads retry configuration from a Typesafe Config instance.
    *
    *  Each key is optional: if absent, the corresponding [[Default]] value is used.
    *  This design ensures backward-compatibility — existing configs that omit the

--- a/agent/src/test/resources/reference.conf
+++ b/agent/src/test/resources/reference.conf
@@ -20,3 +20,12 @@ atum.dispatcher.type="console"
 # Maximum number of dispatch captures to keep in memory
 # atum.dispatcher.capture.capture-limit=1000 # 0 means no limit
 
+# Retry configuration for the HTTP dispatcher (all keys optional — defaults apply if absent)
+#atum.dispatcher.http.retry.max-retries=3          # number of retries after first failure (0 = no retries)
+#atum.dispatcher.http.retry.initial-delay-ms=1000  # initial backoff delay in milliseconds
+#atum.dispatcher.http.retry.max-delay-ms=10000     # maximum backoff delay cap in milliseconds
+
+# HTTP timeout configuration (all keys optional — defaults apply if absent)
+#atum.dispatcher.http.timeout.connect-ms=10000     # TCP connection timeout in milliseconds (default: 10 000)
+#atum.dispatcher.http.timeout.read-ms=30000        # response read timeout in milliseconds (default: 30 000)
+#atum.dispatcher.http.timeout.write-ms=10000       # request write timeout in milliseconds (default: 10 000)

--- a/agent/src/test/scala/za/co/absa/atum/agent/dispatcher/HttpDispatcherUnitTests.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/dispatcher/HttpDispatcherUnitTests.scala
@@ -259,4 +259,35 @@ class HttpDispatcherUnitTests extends AnyFlatSpec with Matchers with BeforeAndAf
     an[HttpException] should be thrownBy dispatcher.saveCheckpoint(checkpoint)
   }
 
+  it should "treat HTTP 409 Conflict as success (checkpoint already saved on prior attempt)" in {
+    val checkpoint = CheckpointDTO(
+      id = java.util.UUID.randomUUID(),
+      name = "cp",
+      author = "author",
+      measuredByAtumAgent = true,
+      processStartTime = ZonedDateTime.now(),
+      processEndTime = Some(ZonedDateTime.now()),
+      measurements = Set.empty,
+      partitioning = testPartitioningDTO
+    )
+    val partitioningWithId = PartitioningWithIdDTO(123L, testPartitioningDTO, "author")
+    val getPartitioningResponse = Response(
+      Right(SingleSuccessResponse(partitioningWithId).asJsonString): Either[String, String],
+      StatusCode.Ok
+    )
+    val conflictResponse = Response(Left("Checkpoint already present"): Either[String, String], StatusCode.Conflict)
+
+    stubGetPartitioning(testPartitioningDTO, getPartitioningResponse)
+    when(
+      mockBackend.send(
+        argThat[Request[Either[String, String], capabilities.WebSockets]](
+          req => req.method.method == "POST" && req.uri.path.mkString.contains("checkpoints")
+        )
+      )
+    ).thenReturn(conflictResponse)
+
+    // Should NOT throw — 409 means the checkpoint was already saved
+    noException should be thrownBy dispatcher.saveCheckpoint(checkpoint)
+  }
+
 }

--- a/agent/src/test/scala/za/co/absa/atum/agent/dispatcher/HttpRetryUnitTests.scala
+++ b/agent/src/test/scala/za/co/absa/atum/agent/dispatcher/HttpRetryUnitTests.scala
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.atum.agent.dispatcher
+
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.capabilities
+import sttp.client3._
+import sttp.model.StatusCode
+import za.co.absa.atum.agent.exception.AtumAgentException.HttpException
+import za.co.absa.atum.model.dto._
+import za.co.absa.atum.model.envelopes.SuccessResponse.SingleSuccessResponse
+import za.co.absa.atum.model.utils.JsonSyntaxExtensions.JsonSerializationSyntax
+
+import java.io.IOException
+
+class HttpRetryUnitTests extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
+
+  // ---------------------------------------------------------------------------
+  // Shared fixtures
+  // ---------------------------------------------------------------------------
+
+  var mockBackend: SttpBackend[Identity, sttp.capabilities.WebSockets] = _
+  var mockConfig: Config = _
+  val serverUrl = "http://test-server"
+
+  val testPartitioningDTO: Seq[PartitionDTO] = Seq(PartitionDTO("k", "v"))
+
+  override def beforeEach(): Unit = {
+    mockBackend = mock(classOf[SttpBackend[Identity, sttp.capabilities.WebSockets]])
+    mockConfig = mock(classOf[Config])
+    // getString is called for UrlKey during HttpDispatcher construction
+    when(mockConfig.getString(any[String])).thenReturn(serverUrl)
+    // hasPath is called by HttpRetry.fromConfig; returning false causes Default to be used
+    when(mockConfig.hasPath(any[String])).thenReturn(false)
+  }
+
+  /** Dispatcher backed by mockConfig (uses HttpRetry.Default: maxRetries=3). */
+  def dispatcher: HttpDispatcher = new HttpDispatcher(mockConfig) {
+    override private[dispatcher] val backend = mockBackend
+  }
+
+  /**
+   * Builds a real Typesafe Config with explicit retry settings.
+   * Using ConfigFactory avoids mocking hasPath/getInt/getLong interactions.
+   * Delays are set to 1 ms by default so tests complete in milliseconds.
+   */
+  def configWithRetry(
+    maxRetries: Int,
+    initialDelayMs: Long = 1L,
+    maxDelayMs: Long = 50L
+  ): Config =
+    ConfigFactory.empty()
+      .withValue("atum.dispatcher.http.url",
+        ConfigValueFactory.fromAnyRef(serverUrl))
+      .withValue("atum.dispatcher.http.retry.max-retries",
+        ConfigValueFactory.fromAnyRef(maxRetries))
+      .withValue("atum.dispatcher.http.retry.initial-delay-ms",
+        ConfigValueFactory.fromAnyRef(initialDelayMs))
+      .withValue("atum.dispatcher.http.retry.max-delay-ms",
+        ConfigValueFactory.fromAnyRef(maxDelayMs))
+
+  /** Dispatcher backed by a real config — use when testing custom retry counts/delays. */
+  def dispatcherWithConfig(cfg: Config): HttpDispatcher = new HttpDispatcher(cfg) {
+    override private[dispatcher] val backend = mockBackend
+  }
+
+  // ---------------------------------------------------------------------------
+  // Response helpers
+  // ---------------------------------------------------------------------------
+
+  def okPartitioningResponse(id: Long): Response[Either[String, String]] = {
+    val dto = PartitioningWithIdDTO(id, testPartitioningDTO, "author")
+    Response(
+      Right(SingleSuccessResponse(dto).asJsonString): Either[String, String],
+      StatusCode.Ok
+    )
+  }
+
+  val serverErrorResponse: Response[Either[String, String]] =
+    Response(Left("Internal Server Error"): Either[String, String], StatusCode.InternalServerError)
+
+  val serviceUnavailableResponse: Response[Either[String, String]] =
+    Response(Left("Service Unavailable"): Either[String, String], StatusCode.ServiceUnavailable)
+
+  val badRequestResponse: Response[Either[String, String]] =
+    Response(Left("Bad Request"): Either[String, String], StatusCode.BadRequest)
+
+  val notFoundResponse: Response[Either[String, String]] =
+    Response(Left("Not Found"): Either[String, String], StatusCode.NotFound)
+
+  // ---------------------------------------------------------------------------
+  // withRetry — 5xx retry behaviour
+  // ---------------------------------------------------------------------------
+
+  "withRetry" should "succeed on first attempt without issuing any retry" in {
+    when(mockBackend.send(any[Request[Either[String, String], capabilities.WebSockets]]))
+      .thenReturn(okPartitioningResponse(42L))
+
+    val result = dispatcher.getPartitioningId(testPartitioningDTO)
+
+    result shouldBe 42L
+    verify(mockBackend, times(1)).send(any[Request[Either[String, String], capabilities.WebSockets]])
+  }
+
+  it should "retry on HTTP 503 and succeed on the second attempt" in {
+    when(mockBackend.send(any[Request[Either[String, String], capabilities.WebSockets]]))
+      .thenReturn(serviceUnavailableResponse)  // attempt 1: 503
+      .thenReturn(okPartitioningResponse(99L)) // attempt 2: 200
+
+    val d = dispatcherWithConfig(configWithRetry(maxRetries = 1))
+    val result = d.getPartitioningId(testPartitioningDTO)
+
+    result shouldBe 99L
+    verify(mockBackend, times(2)).send(any[Request[Either[String, String], capabilities.WebSockets]])
+  }
+
+  it should "retry on HTTP 500 and succeed on the third attempt" in {
+    when(mockBackend.send(any[Request[Either[String, String], capabilities.WebSockets]]))
+      .thenReturn(serverErrorResponse)         // attempt 1: 500
+      .thenReturn(serverErrorResponse)         // attempt 2: 500
+      .thenReturn(okPartitioningResponse(7L))  // attempt 3: 200
+
+    val d = dispatcherWithConfig(configWithRetry(maxRetries = 2))
+    val result = d.getPartitioningId(testPartitioningDTO)
+
+    result shouldBe 7L
+    verify(mockBackend, times(3)).send(any[Request[Either[String, String], capabilities.WebSockets]])
+  }
+
+  it should "throw HttpException after exhausting retries on persistent 5xx" in {
+    // Always returns 500 — retries = 2 means 3 total send() calls (1 + 2 retries)
+    when(mockBackend.send(any[Request[Either[String, String], capabilities.WebSockets]]))
+      .thenReturn(serverErrorResponse)
+
+    val d = dispatcherWithConfig(configWithRetry(maxRetries = 2))
+
+    val thrown = intercept[HttpException] {
+      d.getPartitioningId(testPartitioningDTO)
+    }
+
+    thrown.statusCode shouldBe 500
+    verify(mockBackend, times(3)).send(any[Request[Either[String, String], capabilities.WebSockets]])
+  }
+
+  // ---------------------------------------------------------------------------
+  // withRetry — 4xx NO-retry behaviour
+  // ---------------------------------------------------------------------------
+
+  it should "NOT retry on HTTP 400 (client error) and throw HttpException immediately" in {
+    when(mockBackend.send(any[Request[Either[String, String], capabilities.WebSockets]]))
+      .thenReturn(badRequestResponse)
+
+    val d = dispatcherWithConfig(configWithRetry(maxRetries = 3))
+
+    an[HttpException] should be thrownBy d.getPartitioningId(testPartitioningDTO)
+    // Exactly one send() call — no retry
+    verify(mockBackend, times(1)).send(any[Request[Either[String, String], capabilities.WebSockets]])
+  }
+
+  it should "NOT retry on HTTP 404 (not found) and return None from getPartitioning" in {
+    when(mockBackend.send(any[Request[Either[String, String], capabilities.WebSockets]]))
+      .thenReturn(notFoundResponse)
+
+    val d = dispatcherWithConfig(configWithRetry(maxRetries = 3))
+    val result = d.getPartitioning(testPartitioningDTO)
+
+    result shouldBe None
+    // Exactly one send() call — no retry
+    verify(mockBackend, times(1)).send(any[Request[Either[String, String], capabilities.WebSockets]])
+  }
+
+  // ---------------------------------------------------------------------------
+  // withRetry — IOException retry behaviour (RETRY-01)
+  // ---------------------------------------------------------------------------
+
+  it should "retry on IOException and succeed on the second attempt" in {
+    val ioException = new IOException("connection reset")
+    // thenThrow(checked IOException) fails Mockito's signature check; use thenAnswer instead
+    when(mockBackend.send(any[Request[Either[String, String], capabilities.WebSockets]]))
+      .thenAnswer(new org.mockito.stubbing.Answer[Response[Either[String, String]]] {
+        override def answer(invocation: org.mockito.invocation.InvocationOnMock): Response[Either[String, String]] =
+          throw ioException
+      })
+      .thenReturn(okPartitioningResponse(55L)) // attempt 2: 200
+
+    val d = dispatcherWithConfig(configWithRetry(maxRetries = 1))
+    val result = d.getPartitioningId(testPartitioningDTO)
+
+    result shouldBe 55L
+    verify(mockBackend, times(2)).send(any[Request[Either[String, String], capabilities.WebSockets]])
+  }
+
+  it should "throw IOException after exhausting retries on persistent IOException" in {
+    val ioException = new IOException("connection refused")
+    // thenThrow(checked IOException) fails Mockito's signature check; use thenAnswer instead
+    when(mockBackend.send(any[Request[Either[String, String], capabilities.WebSockets]]))
+      .thenAnswer(new org.mockito.stubbing.Answer[Response[Either[String, String]]] {
+        override def answer(invocation: org.mockito.invocation.InvocationOnMock): Response[Either[String, String]] =
+          throw ioException
+      })
+
+    val d = dispatcherWithConfig(configWithRetry(maxRetries = 2))
+
+    // 1 original + 2 retries = 3 send() calls, then IOException is rethrown
+    an[IOException] should be thrownBy d.getPartitioningId(testPartitioningDTO)
+    verify(mockBackend, times(3)).send(any[Request[Either[String, String], capabilities.WebSockets]])
+  }
+
+  // ---------------------------------------------------------------------------
+  // HttpRetry backward-compatibility and defaults
+  // ---------------------------------------------------------------------------
+
+  it should "exhaust exactly HttpRetry.Default.maxRetries + 1 attempts on persistent 5xx" in {
+    // Verify that Default.maxRetries=3 produces exactly 4 total send() calls
+    when(mockBackend.send(any[Request[Either[String, String], capabilities.WebSockets]]))
+      .thenReturn(serverErrorResponse)
+
+    val d = dispatcherWithConfig(configWithRetry(maxRetries = HttpRetry.Default.maxRetries))
+    an[HttpException] should be thrownBy d.getPartitioningId(testPartitioningDTO)
+    verify(mockBackend, times(HttpRetry.Default.maxRetries + 1))
+      .send(any[Request[Either[String, String], capabilities.WebSockets]])
+  }
+
+  it should "not throw ConfigException when constructing HttpDispatcher from a config with no retry block" in {
+    // A minimal real config with only the URL key — simulates a legacy consumer config
+    val legacyConfig = ConfigFactory.empty()
+      .withValue("atum.dispatcher.http.url", ConfigValueFactory.fromAnyRef(serverUrl))
+
+    // Construction must succeed without ConfigException
+    noException should be thrownBy {
+      new HttpDispatcher(legacyConfig) {
+        override private[dispatcher] val backend = mockBackend
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // maxRetries=0 edge case
+  // ---------------------------------------------------------------------------
+
+  it should "not retry at all when maxRetries is 0" in {
+    when(mockBackend.send(any[Request[Either[String, String], capabilities.WebSockets]]))
+      .thenReturn(serverErrorResponse)
+
+    val d = dispatcherWithConfig(configWithRetry(maxRetries = 0))
+
+    an[HttpException] should be thrownBy d.getPartitioningId(testPartitioningDTO)
+    // maxRetries=0 means no retries: exactly 1 send() call
+    verify(mockBackend, times(1)).send(any[Request[Either[String, String], capabilities.WebSockets]])
+  }
+
+}

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -13,6 +13,7 @@
     maxPoolSize=10  # Max number of connections that HikariCP will keep in the pool, including both idle and in-use ones
     # Connection lifecycle settings
     idleTimeout=180000  # How long a connection can sit idle in the pool before being removed.
+    connectionTimeout=10000  # Max ms to wait for a connection from the pool before throwing. HikariCP default is 30 000 ms.
     keepaliveTime=60000 # How often Hikari sends a keep-alive query to verify the connection is still valid while it's idle in the pool.
     maxLifetime=600000  # Refresh connections regularly
     # Misc settings

--- a/server/src/main/scala/za/co/absa/atum/server/api/database/TransactorProvider.scala
+++ b/server/src/main/scala/za/co/absa/atum/server/api/database/TransactorProvider.scala
@@ -52,6 +52,11 @@ object TransactorProvider {
 
         // Connection lifecycle settings
         config.setIdleTimeout(postgresConfig.idleTimeout)
+        require(
+          postgresConfig.connectionTimeout >= 250L,
+          s"postgres.connectionTimeout must be >= 250 ms (HikariCP minimum), got ${postgresConfig.connectionTimeout} ms"
+        )
+        config.setConnectionTimeout(postgresConfig.connectionTimeout)
         config.setKeepaliveTime(postgresConfig.keepaliveTime)
         config.setMaxLifetime(postgresConfig.maxLifetime)
 

--- a/server/src/main/scala/za/co/absa/atum/server/config/PostgresConfig.scala
+++ b/server/src/main/scala/za/co/absa/atum/server/config/PostgresConfig.scala
@@ -32,7 +32,8 @@ case class PostgresConfig(
   idleTimeout: Int,
   keepaliveTime: Int,
   maxLifetime: Int,
-  leakDetectionThreshold: Int
+  leakDetectionThreshold: Int,
+  connectionTimeout: Long
 )
 
 object PostgresConfig {

--- a/server/src/test/resources/reference.conf
+++ b/server/src/test/resources/reference.conf
@@ -13,6 +13,7 @@
     maxPoolSize=10  # Max number of connections that HikariCP will keep in the pool, including both idle and in-use ones
     # Connection lifecycle settings
     idleTimeout=180000  # How long a connection can sit idle in the pool before being removed.
+    connectionTimeout=10000  # Max ms to wait for a connection from the pool before throwing. HikariCP default is 30 000 ms.
     keepaliveTime=60000 # How often Hikari sends a keep-alive query to verify the connection is still valid while it's idle in the pool.
     maxLifetime=600000  # Refresh connections regularly
     # Misc settings


### PR DESCRIPTION
Closes: #205

# Release Notes:
* Atum Service: adding DB connection timeout parameter for being able to tune this on the server side
* Atum Agent: adding a simple retry mechanism onto the agent's HTTP layer and also changeable settings for timeouts on the HTTP layer (for the underlying OkHTTP client)